### PR TITLE
feat: /status endpoint returns service semver

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -11,6 +11,7 @@ jobs:
     with:
       service-name: lamb2
       docker-tag: latest ${{ github.event.release.tag_name }}
+      build-args: CURRENT_VERSION=${{ github.event.release.tag_name }}
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ ENV NODE_ENV production
 ARG COMMIT_HASH=local
 ENV COMMIT_HASH=${COMMIT_HASH:-local}
 
+ARG CURRENT_VERSION=Unknown
+ENV CURRENT_VERSION=${CURRENT_VERSION:-Unknown}
+
 WORKDIR /app
 COPY --from=builderenv /app /app
 COPY --from=builderenv /tini /tini

--- a/src/controllers/handlers/status-handler.ts
+++ b/src/controllers/handlers/status-handler.ts
@@ -1,23 +1,22 @@
 import { HandlerContextWithPath } from '../../types'
 
-// handlers arguments only type what they need, to make unit testing easier
-export async function statusHandler(
-  context: Pick<HandlerContextWithPath<'metrics' | 'config', '/status'>, 'url' | 'components'>
-) {
+export async function statusHandler(context: Pick<HandlerContextWithPath<'config', '/status'>, 'url' | 'components'>) {
   const {
-    url,
-    components: { metrics, config }
+    components: { config }
   } = context
 
-  metrics.increment('test_status_counter', {
-    pathname: url.pathname
-  })
-
-  const commitHash = (await config.getString('COMMIT_HASH')) ?? ''
+  const [commitHash, contentServerUrl, version] = await Promise.all([
+    config.getString('COMMIT_HASH'),
+    config.getString('CONTENT_SERVER_ADDRESS'),
+    config.getString('CURRENT_VERSION')
+  ])
 
   return {
     body: {
-      commitHash
+      version: version ?? '',
+      currentTime: Date.now(),
+      contentServerUrl: contentServerUrl ?? '',
+      commitHash: commitHash ?? ''
     }
   }
 }

--- a/test/integration/status-controller.spec.ts
+++ b/test/integration/status-controller.spec.ts
@@ -1,24 +1,21 @@
 import { test } from "../components"
 
 test("integration sanity tests using a real server backend", function ({ components, stubComponents }) {
-  it("responds with commitHash", async () => {
+  it("responds with all default properties", async () => {
     const { localFetch } = components
     const r = await localFetch.fetch("/status")
 
     expect(r.status).toEqual(200)
-    expect(await r.json()).toEqual({ commitHash: 'commit_hash' })
+    expect(await r.json()).toEqual({ commitHash: 'commit_hash', contentServerUrl: 'https://peer.decentraland.org/content', currentTime: expect.any(Number), version: '' })
   })
 
-  it("calling /status increments a metric", async () => {
+  it("responds with all default properties + version", async () => {
+    process.env['CURRENT_VERSION'] = 'version'
     const { localFetch } = components
-    const { metrics } = stubComponents
-
     const r = await localFetch.fetch("/status")
 
     expect(r.status).toEqual(200)
-    expect(await r.json()).toEqual({ commitHash: 'commit_hash' })
-
-    expect(metrics.increment.calledOnceWith("test_status_counter", { pathname: "/status" })).toEqual(true)
+    expect(await r.json()).toEqual({ commitHash: 'commit_hash', contentServerUrl: 'https://peer.decentraland.org/content', currentTime: expect.any(Number), version: 'version' })
   })
 
   it("random url responds 404", async () => {
@@ -27,16 +24,5 @@ test("integration sanity tests using a real server backend", function ({ compone
     const r = await localFetch.fetch("/status" + Math.random())
 
     expect(r.status).toEqual(404)
-  })
-
-  it("next call to /status should fail in 'metrics' component", async () => {
-    const { localFetch } = components
-    const { metrics } = stubComponents
-
-    metrics.increment.throwsException("some exception")
-
-    const r = await localFetch.fetch("/status")
-
-    expect(r.status).toEqual(500)
   })
 })

--- a/test/unit/status-controller.spec.ts
+++ b/test/unit/status-controller.spec.ts
@@ -6,35 +6,37 @@ import { metricDeclarations } from "../../src/metrics"
 describe("status-controller-unit", () => {
   it("must return commit hash", async () => {
     const url = new URL("https://github.com/well-known-components")
-    const metrics = createTestMetricsComponent(metricDeclarations)
     const config = await createDotEnvConfigComponent({}, {COMMIT_HASH: 'commit_hash'})
-    expect((await metrics.getValue("test_status_counter")).values).toEqual([])
-    expect(await statusHandler({ url, components: { metrics, config } })).toEqual({ body: { commitHash: 'commit_hash' } })
-    expect((await metrics.getValue("test_status_counter")).values).toEqual([
-      { labels: { pathname: "/well-known-components" }, value: 1 },
-    ])
+    expect(await statusHandler({ url, components: { config } })).toMatchObject({ body: { commitHash: 'commit_hash' } })
   })
 
-  it("metrics should create a brand new registry", async () => {
+  it("must return current version", async () => {
     const url = new URL("https://github.com/well-known-components")
-    const metrics = createTestMetricsComponent(metricDeclarations)
-    const config = await createDotEnvConfigComponent({}, {COMMIT_HASH: 'commit_hash'})
-    expect((await metrics.getValue("test_status_counter")).values).toEqual([])
-    expect(await statusHandler({ url, components: { metrics, config } })).toEqual({ body: { commitHash: 'commit_hash' } })
-    expect((await metrics.getValue("test_status_counter")).values).toEqual([
-      { labels: { pathname: "/well-known-components" }, value: 1 },
-    ])
+    const config = await createDotEnvConfigComponent({}, {CURRENT_VERSION: 'current_version'})
+    expect(await statusHandler({ url, components: { config } })).toMatchObject({ body: { version: 'current_version' } })
   })
 
-  it("calling twice should increment twice the metrics", async () => {
+  it("must return default content server address", async () => {
     const url = new URL("https://github.com/well-known-components")
-    const metrics = createTestMetricsComponent(metricDeclarations)
-    const config = await createDotEnvConfigComponent({}, {COMMIT_HASH: 'commit_hash'})
-    expect((await metrics.getValue("test_status_counter")).values).toEqual([])
-    expect(await statusHandler({ url, components: { metrics, config } })).toEqual({ body: { commitHash: 'commit_hash' } })
-    expect(await statusHandler({ url, components: { metrics, config } })).toEqual({ body: { commitHash: 'commit_hash' } })
-    expect((await metrics.getValue("test_status_counter")).values).toEqual([
-      { labels: { pathname: "/well-known-components" }, value: 2 },
-    ])
+    const config = await createDotEnvConfigComponent({}, {})
+    expect(await statusHandler({ url, components: { config } })).toMatchObject({ body: { contentServerUrl: 'https://peer.decentraland.org/content' } })
+  })
+
+  it("must return default content server address", async () => {
+    const url = new URL("https://github.com/well-known-components")
+    const config = await createDotEnvConfigComponent({}, {})
+    expect(await statusHandler({ url, components: { config } })).toMatchObject({ body: { contentServerUrl: 'https://peer.decentraland.org/content' } })
+  })
+
+  it("must return currentTime", async () => {
+    const url = new URL("https://github.com/well-known-components")
+    const config = await createDotEnvConfigComponent({}, {})
+    expect(await statusHandler({ url, components: { config } })).toMatchObject({ body: { currentTime: expect.any(Number) } })
+  })
+
+  it("must return empty for values that does not have default value", async () => {
+    const url = new URL("https://github.com/well-known-components")
+    const config = await createDotEnvConfigComponent({}, {})
+    expect(await statusHandler({ url, components: { config } })).toMatchObject({ body: { commitHash: '', version: '' } })
   })
 })


### PR DESCRIPTION
Update /status endpoint to expose:
* Service semver as `version` -> pulled from CURRENT_VERSION
* currentTime -> Date.now()
* contentServerUrl -> pulled from CONTENT_SERVER_ADDRESS already in place
* commitHash -> pulled from COMMIT_HASH already in place

This information, specifically the semver, will be used to enhance the algorithm picking.