### PR TITLE
chore: migrate /contracts endpoints, remove ethers, faster /about 

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@dcl/catalyst-api-specs": "^3.2.0",
+    "@dcl/catalyst-contracts": "^4.0.2",
     "@dcl/crypto": "^3.4.1",
     "@dcl/schemas": "^7.2.0",
     "@dcl/urn-resolver": "^2.0.3",
@@ -37,7 +38,7 @@
     "@well-known-components/metrics": "^2.0.1",
     "@well-known-components/thegraph-component": "^1.5.0",
     "dcl-catalyst-client": "^19.0.0",
-    "ethers": "^6.4.0",
+    "eth-connect": "^6.1.0",
     "lodash": "^4.17.21",
     "lru-cache": "^8.0.4"
   }

--- a/src/adapters/catalysts-fetcher.ts
+++ b/src/adapters/catalysts-fetcher.ts
@@ -1,0 +1,64 @@
+import { IBaseComponent } from '@well-known-components/interfaces'
+import RequestManager, { bytesToHex, ContractFactory } from 'eth-connect'
+import LRUCache from 'lru-cache'
+import { AppComponents } from '../types'
+import {
+  catalystAbi,
+  CatalystByIdResult,
+  getCatalystServersFromDAO,
+  l1Contracts,
+  L1Network
+} from '@dcl/catalyst-contracts'
+
+export type Server = {
+  baseUrl: string
+  owner: string
+  id: string
+}
+
+export type CatalystsFetcher = IBaseComponent & {
+  getCatalystServers(): Promise<Server[]>
+}
+
+const HOUR_MS = 1000 * 60 * 60
+
+export async function createCatalystsFetcher(
+  { l1Provider }: Pick<AppComponents, 'l1Provider'>,
+  network: L1Network
+): Promise<CatalystsFetcher> {
+  const requestManager = new RequestManager(l1Provider)
+  const factory = new ContractFactory(requestManager, catalystAbi)
+  const contract = (await factory.at(l1Contracts[network].catalyst)) as any
+  const catalystContract = {
+    async catalystCount(): Promise<number> {
+      return contract.catalystCount()
+    },
+    async catalystIds(i: number): Promise<string> {
+      return contract.catalystIds(i)
+    },
+    async catalystById(catalystId: string): Promise<CatalystByIdResult> {
+      const [id, owner, domain] = await contract.catalystById(catalystId)
+      return { id: '0x' + bytesToHex(id), owner, domain }
+    }
+  }
+
+  const catalysts = new LRUCache<number, Server[]>({
+    max: 1,
+    ttl: HOUR_MS * 6,
+    fetchMethod: async function (_: number): Promise<Server[]> {
+      const catalysts = await getCatalystServersFromDAO(catalystContract)
+      return catalysts.map(({ owner, id, address }) => {
+        return { baseUrl: address, owner, id }
+      })
+    }
+  })
+
+  async function getCatalystServers(): Promise<Server[]> {
+    const servers = await catalysts.fetch(0)
+    return servers || []
+  }
+
+  return {
+    getCatalystServers
+  }
+}

--- a/src/adapters/name-denylist-fetcher.ts
+++ b/src/adapters/name-denylist-fetcher.ts
@@ -1,0 +1,42 @@
+import { IBaseComponent } from '@well-known-components/interfaces'
+import RequestManager, { ContractFactory } from 'eth-connect'
+import LRUCache from 'lru-cache'
+import { AppComponents } from '../types'
+import {
+  getNameDenylistFromContract,
+  l1Contracts,
+  L1Network,
+  listAbi,
+  NameDenylistContract
+} from '@dcl/catalyst-contracts'
+
+export type NameDenylistFetcher = IBaseComponent & {
+  getNameDenylist(): Promise<string[]>
+}
+
+const HOUR_MS = 1000 * 60 * 60
+
+export async function createNameDenylistFetcher(
+  { l1Provider }: Pick<AppComponents, 'l1Provider'>,
+  network: L1Network
+): Promise<NameDenylistFetcher> {
+  const requestManager = new RequestManager(l1Provider)
+  const factory = new ContractFactory(requestManager, listAbi)
+  const contract: NameDenylistContract = (await factory.at(l1Contracts[network].nameDenylist)) as any
+
+  const cache = new LRUCache<number, string[]>({
+    max: 1,
+    ttl: HOUR_MS * 6,
+    fetchMethod: async function (_: number): Promise<string[]> {
+      return getNameDenylistFromContract(contract)
+    }
+  })
+
+  async function getNameDenylist(): Promise<string[]> {
+    return (await cache.fetch(0)) || []
+  }
+
+  return {
+    getNameDenylist
+  }
+}

--- a/src/adapters/pois-fetcher.ts
+++ b/src/adapters/pois-fetcher.ts
@@ -1,0 +1,36 @@
+import { IBaseComponent } from '@well-known-components/interfaces'
+import RequestManager, { ContractFactory } from 'eth-connect'
+import LRUCache from 'lru-cache'
+import { AppComponents } from '../types'
+import { getPoisFromContract, l2Contracts, L2Network, listAbi, PoiContract } from '@dcl/catalyst-contracts'
+
+export type POIsFetcher = IBaseComponent & {
+  getPOIs(): Promise<string[]>
+}
+
+const HOUR_MS = 1000 * 60 * 60
+
+export async function createPOIsFetcher(
+  { l2Provider }: Pick<AppComponents, 'l2Provider'>,
+  network: L2Network
+): Promise<POIsFetcher> {
+  const requestManager = new RequestManager(l2Provider)
+  const factory = new ContractFactory(requestManager, listAbi)
+  const contract: PoiContract = (await factory.at(l2Contracts[network].poi)) as any
+
+  const cache = new LRUCache<number, string[]>({
+    max: 1,
+    ttl: HOUR_MS * 6,
+    fetchMethod: async function (_: number): Promise<string[]> {
+      return getPoisFromContract(contract)
+    }
+  })
+
+  async function getPOIs(): Promise<string[]> {
+    return (await cache.fetch(0)) || []
+  }
+
+  return {
+    getPOIs
+  }
+}

--- a/src/controllers/handlers/about-handler.ts
+++ b/src/controllers/handlers/about-handler.ts
@@ -69,7 +69,7 @@ export async function aboutHandler(
     status.getServiceStatus<StatusContent>(contentUrl.statusUrl),
     status.getServiceStatus<DefaultStatus>(lambdasUrl.statusUrl),
     resourcesStatusCheck.areResourcesOverloaded(),
-    realmName.getValidatedRealmName()
+    realmName.getRealmName()
   ])
 
   const healthy = archipelagoStatus.healthy && contentStatus.healthy && lambdasStatus.healthy

--- a/src/controllers/handlers/catalyst-servers-handler.ts
+++ b/src/controllers/handlers/catalyst-servers-handler.ts
@@ -1,0 +1,11 @@
+import { Servers } from '@dcl/catalyst-api-specs/lib/client'
+import { HandlerContextWithPath } from '../../types'
+
+export async function getCatalystServersHandler(
+  context: Pick<HandlerContextWithPath<'catalystsFetcher', '/contracts/servers'>, 'url' | 'components'>
+): Promise<{ status: 200; body: Servers }> {
+  return {
+    status: 200,
+    body: await context.components.catalystsFetcher.getCatalystServers()
+  }
+}

--- a/src/controllers/handlers/get-name-denylist-handler.ts
+++ b/src/controllers/handlers/get-name-denylist-handler.ts
@@ -1,0 +1,11 @@
+import { DenylistedUsernames } from '@dcl/catalyst-api-specs/lib/client'
+import { HandlerContextWithPath } from '../../types'
+
+export async function getNameDenylistHandler(
+  context: Pick<HandlerContextWithPath<'nameDenylistFetcher', '/contracts/denylisted-names'>, 'url' | 'components'>
+): Promise<{ status: 200; body: DenylistedUsernames }> {
+  return {
+    status: 200,
+    body: await context.components.nameDenylistFetcher.getNameDenylist()
+  }
+}

--- a/src/controllers/handlers/get-pois-handler.ts
+++ b/src/controllers/handlers/get-pois-handler.ts
@@ -1,0 +1,11 @@
+import { Pois } from '@dcl/catalyst-api-specs/lib/client'
+import { HandlerContextWithPath } from '../../types'
+
+export async function getPOIsHandler(
+  context: Pick<HandlerContextWithPath<'poisFetcher', '/contracts/pois'>, 'url' | 'components'>
+): Promise<{ status: 200; body: Pois }> {
+  return {
+    status: 200,
+    body: await context.components.poisFetcher.getPOIs()
+  }
+}

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -16,6 +16,9 @@ import { explorerHandler } from './handlers/explorer-handler'
 import { errorHandler } from './handlers/errorHandler'
 import { aboutHandler } from './handlers/about-handler'
 import { outfitsHandler } from './handlers/outfits-handler'
+import { getCatalystServersHandler } from './handlers/catalyst-servers-handler'
+import { getNameDenylistHandler } from './handlers/get-name-denylist-handler'
+import { getPOIsHandler } from './handlers/get-pois-handler'
 
 // We return the entire router because it will be easier to test than a whole server
 export async function setupRouter(_: GlobalContext): Promise<Router<GlobalContext>> {
@@ -35,6 +38,9 @@ export async function setupRouter(_: GlobalContext): Promise<Router<GlobalContex
   router.get('/profiles/:id', profileHandler)
   router.get('/nfts/collections', allCollectionsHandler)
   router.get('/outfits/:id', outfitsHandler)
+  router.get('/contracts/servers', getCatalystServersHandler)
+  router.get('/contracts/pois', getPOIsHandler)
+  router.get('/contracts/denylisted-names', getNameDenylistHandler)
 
   /* internal */
   router.get('/explorer/:address/wearables', explorerHandler)

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -2,29 +2,16 @@ import { IMetricsComponent } from '@well-known-components/interfaces'
 import { validateMetricsDeclaration } from '@well-known-components/metrics'
 import { getDefaultHttpMetrics } from '@well-known-components/metrics/dist/http'
 import { metricDeclarations as logMetricDeclarations } from '@well-known-components/logger'
+import { metricDeclarations as theGraphMetricDeclarations } from '@well-known-components/thegraph-component'
 
 export const metricDeclarations = {
   ...getDefaultHttpMetrics(),
   ...logMetricDeclarations,
-  test_status_counter: {
-    help: 'Count calls to ping',
-    type: IMetricsComponent.CounterType,
-    labelNames: ['pathname']
-  },
+  ...theGraphMetricDeclarations,
   profiles_counter: {
     help: 'Count calls to profiles',
     type: IMetricsComponent.CounterType,
     labelNames: ['pathname', 'ids']
-  },
-  subgraph_ok_total: {
-    help: 'Count total calls to subgraph',
-    type: IMetricsComponent.CounterType,
-    labelNames: ['url']
-  },
-  subgraph_errors_total: {
-    help: 'Count total calls to subgraph',
-    type: IMetricsComponent.CounterType,
-    labelNames: ['url', 'errorMessage']
   },
   dcl_lamb2_server_build_info: {
     help: 'Lamb2 server static build info.',

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,10 +19,13 @@ import type {
 } from '@well-known-components/interfaces'
 import { Variables } from '@well-known-components/thegraph-component'
 import { ContentClient } from 'dcl-catalyst-client'
-import { Provider } from 'ethers'
+import { HTTPProvider } from 'eth-connect'
+import { CatalystsFetcher } from './adapters/catalysts-fetcher'
 import { DefinitionsFetcher } from './adapters/definitions-fetcher'
 import { ElementsFetcher } from './adapters/elements-fetcher'
 import { EntitiesFetcher } from './adapters/entities-fetcher'
+import { NameDenylistFetcher } from './adapters/name-denylist-fetcher'
+import { POIsFetcher } from './adapters/pois-fetcher'
 import { IRealmNameComponent } from './adapters/realm-name-validator'
 import { IResourcesStatusComponent } from './adapters/resource-status'
 import { IStatusComponent } from './adapters/status'
@@ -59,7 +62,11 @@ export type BaseComponents = {
   resourcesStatusCheck: IResourcesStatusComponent
   status: IStatusComponent
   realmName: IRealmNameComponent
-  provider: Provider
+  l1Provider: HTTPProvider
+  l2Provider: HTTPProvider
+  catalystsFetcher: CatalystsFetcher
+  poisFetcher: POIsFetcher
+  nameDenylistFetcher: NameDenylistFetcher
 }
 
 // components used in runtime

--- a/test/unit/about-controller.spec.ts
+++ b/test/unit/about-controller.spec.ts
@@ -16,7 +16,7 @@ describe('about-controller-unit', () => {
     MAX_USERS: '400'
   }
 
-  async function getValidatedRealmName(): Promise<string | undefined> {
+  async function getRealmName(): Promise<string | undefined> {
     return 'testName'
   }
 
@@ -36,7 +36,7 @@ describe('about-controller-unit', () => {
       config,
       status: { getServiceStatus },
       resourcesStatusCheck: { areResourcesOverloaded },
-      realmName: { getValidatedRealmName }
+      realmName: { getRealmName }
     }
 
     const response = await aboutHandler({ url, components })
@@ -116,7 +116,7 @@ describe('about-controller-unit', () => {
       config,
       status: { getServiceStatus },
       resourcesStatusCheck: { areResourcesOverloaded },
-      realmName: { getValidatedRealmName }
+      realmName: { getRealmName }
     }
 
     const response = await aboutHandler({ url, components })
@@ -198,7 +198,7 @@ describe('about-controller-unit', () => {
       config,
       status: { getServiceStatus },
       resourcesStatusCheck: { areResourcesOverloaded },
-      realmName: { getValidatedRealmName }
+      realmName: { getRealmName }
     }
 
     const response = await aboutHandler({ url, components })
@@ -280,7 +280,7 @@ describe('about-controller-unit', () => {
       config,
       status: { getServiceStatus },
       resourcesStatusCheck: { areResourcesOverloaded },
-      realmName: { getValidatedRealmName }
+      realmName: { getRealmName }
     }
 
     const response = await aboutHandler({ url, components })

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,6 +306,11 @@
   resolved "https://registry.yarnpkg.com/@dcl/catalyst-api-specs/-/catalyst-api-specs-3.2.1.tgz#6d15382326bf9fbe86bc9325f1388896d3e81e16"
   integrity sha512-9yHFLUg3PcwwTcZupeelpruFFNg+lD1/+YQ3dwfz0l3gWtjPXGSmAAYaggtyqiukbObjs7cbxagx4RjsBmMkpw==
 
+"@dcl/catalyst-contracts@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@dcl/catalyst-contracts/-/catalyst-contracts-4.0.2.tgz#9f77e1b4c857eff2ac6c550b8681ff6744680709"
+  integrity sha512-lfLtj4e646xCl/09seLq8zVnbuQ2w1O0c678TRB+1dttGYPpD13osX3J1P7ikC2SoR4NEBgDlFYXGbppmf0NKQ==
+
 "@dcl/crypto@^3.4.0", "@dcl/crypto@^3.4.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@dcl/crypto/-/crypto-3.4.1.tgz#2ab9b9b5b18efbe5d65eee3936c0f73c20480858"
@@ -2519,7 +2524,7 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
-eth-connect@^6.0.3:
+eth-connect@^6.0.3, eth-connect@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/eth-connect/-/eth-connect-6.1.0.tgz#94df7e019592825f0d2ee2429d19baf9fa3c5136"
   integrity sha512-p5FN4GieTxwfJvgmGCPgXqL6w8/2cbLiTmNxpgQg881gSI0RdOShTHHu8amgxlj3VM4crovBx7UEKS2RGOhBLQ==


### PR DESCRIPTION
/about now returns the realm name defined while validating on background, if the realm is invalid it will be invalidated later and won't be included anymore