### PR TITLE
reference: enhance NFT items identification through token id

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "dependencies": {
     "@dcl/catalyst-api-specs": "^3.2.3",
     "@dcl/catalyst-contracts": "^4.1.0",
-    "@dcl/crypto": "^3.4.3",
     "@dcl/schemas": "^9.1.1",
-    "@dcl/urn-resolver": "^2.2.0",
+    "@dcl/crypto": "^3.4.3",
+    "@dcl/urn-resolver": "3.1.0",
     "@well-known-components/env-config-provider": "^1.2.0",
     "@well-known-components/http-server": "^2.0.0",
     "@well-known-components/interfaces": "^1.4.2",

--- a/src/controllers/handlers/outfits-handler.ts
+++ b/src/controllers/handlers/outfits-handler.ts
@@ -8,7 +8,11 @@ export async function outfitsHandler(
     '/outfits/:id'
   >
 ): Promise<{ status: 200; body: Entity }> {
-  const outfits = await getOutfits(context.components, `${context.params.id}`)
+  // This property ensures that all the NFTs being returned by this endpoint
+  // will contain the tokenId part as described on the ERC-721 standard
+  const ensureERC721Standard = context.url.searchParams.has('erc721')
+
+  const outfits = await getOutfits(context.components, `${context.params.id}`, ensureERC721Standard)
   if (!outfits) {
     throw new NotFoundError('Outfits not found')
   }

--- a/src/logic/fetch-elements/fetch-items.ts
+++ b/src/logic/fetch-elements/fetch-items.ts
@@ -11,7 +11,7 @@ function groupItemsByURN<
 
   items.forEach((itemFromQuery) => {
     const individualData = {
-      id: itemFromQuery.id,
+      id: itemFromQuery.urn + ':' + itemFromQuery.tokenId,
       tokenId: itemFromQuery.tokenId,
       transferredAt: itemFromQuery.transferredAt,
       price: itemFromQuery.item.price

--- a/src/logic/maps.ts
+++ b/src/logic/maps.ts
@@ -1,3 +1,5 @@
+import { resolveUrn } from './utils'
+
 /*
  * Merge map1 into map2. They must be { string -> [string] } maps
  */
@@ -8,6 +10,21 @@ export function mergeMapIntoMap(map1: Map<string, string[]>, map2: Map<string, s
       map2.set(key, map2Val?.concat(val))
     } else {
       map2.set(key, val)
+    }
+  }
+}
+
+export function mergeMapIntoMapExtended(
+  map1: Map<string, string[]>,
+  map2: Map<string, { urn: string; tokenId: string | undefined }[]>
+) {
+  for (const [key, val] of map1) {
+    const parsedVal = val.map(resolveUrn)
+    if (map2.has(key)) {
+      const map2Val = map2.get(key) ?? []
+      map2.set(key, map2Val.concat(parsedVal))
+    } else {
+      map2.set(key, parsedVal)
     }
   }
 }

--- a/src/logic/outfits.ts
+++ b/src/logic/outfits.ts
@@ -2,10 +2,12 @@ import { Outfits } from '@dcl/schemas'
 import { createNamesOwnershipChecker } from '../ports/ownership-checker/names-ownership-checker'
 import { createWearablesOwnershipChecker } from '../ports/ownership-checker/wearables-ownership-checker'
 import { AppComponents, TypedEntity } from '../types'
+import { isBaseWearable, resolveUrn } from './utils'
 
 export async function getOutfits(
   components: Pick<AppComponents, 'metrics' | 'content' | 'theGraph' | 'config' | 'fetch' | 'ownershipCaches'>,
-  ethAddress: string
+  ethAddress: string,
+  ensureERC721Standard: boolean
 ): Promise<TypedEntity<Outfits> | undefined> {
   const outfitsEntities: TypedEntity<Outfits>[] = await components.content.fetchEntitiesByPointers([
     `${ethAddress}:outfits`
@@ -27,23 +29,26 @@ export async function getOutfits(
   }
 
   const wearablesOwnershipChecker = createWearablesOwnershipChecker(components)
-  const outfitsWearables = outfits.outfits.map((outfit) => outfit.outfit.wearables).flat()
-  wearablesOwnershipChecker.addNFTsForAddress(ethAddress, outfitsWearables)
-  wearablesOwnershipChecker.checkNFTsOwnership()
+  const outfitsWearables = outfits.outfits.flatMap((outfit) =>
+    outfit.outfit.wearables.filter((wearable) => !isBaseWearable(wearable))
+  )
 
-  const ownedWearables = new Set(wearablesOwnershipChecker.getOwnedNFTsForAddress(ethAddress))
-  const outfitsWithOwnedWearables = outfits.outfits.filter((outfit) => {
-    const outfitWearables = outfit.outfit.wearables
-    return outfitWearables.every((wearable) => ownedWearables.has(wearable))
-  })
+  await wearablesOwnershipChecker.addNFTsForAddress(ethAddress, outfitsWearables)
+  await wearablesOwnershipChecker.checkNFTsOwnership()
+
+  const ownedWearables = new Set(
+    wearablesOwnershipChecker.getOwnedNFTsForAddress(ethAddress).map((urn) => urn.urn + ':' + urn.tokenId)
+  )
+
+  const ownedOutfits = getMatchingOutfits(outfits, ownedWearables, ensureERC721Standard)
 
   const namesOwnershipChecker = createNamesOwnershipChecker(components)
   namesOwnershipChecker.addNFTsForAddress(ethAddress, outfits.namesForExtraSlots)
   namesOwnershipChecker.checkNFTsOwnership()
   const ownedNames = new Set(namesOwnershipChecker.getOwnedNFTsForAddress(ethAddress))
 
-  const normalOutfitsWithOwnedWearables = outfitsWithOwnedWearables.filter((outfit) => outfit.slot <= 4)
-  const extraOutfitsWithOwnedWearables = outfitsWithOwnedWearables.filter((outfit) => outfit.slot > 4)
+  const normalOutfitsWithOwnedWearables = ownedOutfits.filter((outfit) => outfit.slot <= 4)
+  const extraOutfitsWithOwnedWearables = ownedOutfits.filter((outfit) => outfit.slot > 4)
   const extraOutfitsWithOwnedWearablesAndNames = extraOutfitsWithOwnedWearables.slice(0, ownedNames.size)
 
   return {
@@ -53,4 +58,46 @@ export async function getOutfits(
       namesForExtraSlots: Array.from(ownedNames)
     }
   }
+}
+
+function getMatchingOutfits(outfits: Outfits, ownedWearables: Set<string>, ensureERC721Standard: boolean) {
+  const parsedOutfits = outfits.outfits.map((outfit) => {
+    const { wearables } = outfit.outfit
+    let match = false
+
+    match = wearables.map(resolveUrn).every((wearableOnOutfit) => {
+      if (wearableOnOutfit.urn.includes('off-chain')) {
+        return true
+      }
+
+      return wearableOnOutfit.tokenId
+        ? ownedWearables.has(`${wearableOnOutfit.urn}:${wearableOnOutfit.tokenId}`)
+        : Array.from(ownedWearables).some((ownedWearable) => ownedWearable.startsWith(wearableOnOutfit.urn))
+    })
+
+    return {
+      outfit: outfit,
+      match: match
+    }
+  })
+
+  return parsedOutfits
+    .filter((result) => result.match)
+    .map((result) => ({
+      ...result.outfit,
+      outfit: {
+        ...result.outfit.outfit,
+        wearables: result.outfit.outfit.wearables
+          .map((wearableOnOutfit) => {
+            if (isBaseWearable(wearableOnOutfit)) {
+              return wearableOnOutfit
+            }
+
+            return ensureERC721Standard
+              ? Array.from(ownedWearables).find((ownedWearable) => ownedWearable.startsWith(wearableOnOutfit)) || ''
+              : wearableOnOutfit
+          })
+          .filter((parsedWearable) => !!parsedWearable)
+      }
+    }))
 }

--- a/src/logic/ownership.ts
+++ b/src/logic/ownership.ts
@@ -25,6 +25,36 @@ export async function ownedNFTsByAddress(
 }
 
 /*
+ * Checks the ownership for every nft resulting in a map of ownership for every eth address.
+ * Receive a `querySubgraph` method to know how to do the query.
+ */
+export async function ownedExtendedNFTsByAddress(
+  components: Pick<AppComponents, 'theGraph' | 'config'>,
+  nftIdsByAddressToCheck: Map<string, { urn: string; tokenId: string | undefined }[]>,
+  querySubgraph: (
+    theGraph: TheGraphComponent,
+    nftsToCheck: [string, { urn: string; tokenId: string | undefined }[]][]
+  ) => any
+): Promise<Map<string, { urn: string; tokenId: string | undefined }[]>> {
+  // Check ownership for unknown nfts
+  const ownedNftIdsByEthAddress = await querySubgraphByFragmentsExtended(
+    components,
+    nftIdsByAddressToCheck,
+    querySubgraph
+  )
+
+  // Fill the final map with nfts ownership
+  for (const [ethAddress, nfts] of nftIdsByAddressToCheck) {
+    const ownedNfts = ownedNftIdsByEthAddress.get(ethAddress)
+    // If the query to the subgraph failed, then consider the nft as owned
+    if (!ownedNfts) {
+      ownedNftIdsByEthAddress.set(ethAddress, nfts)
+    }
+  }
+  return ownedNftIdsByEthAddress
+}
+
+/*
  * Return a set of the NFTs that are actually owned by the eth address, for every eth address.
  * Receive a `querySubgraph` method to know how to do the query.
  */
@@ -37,6 +67,44 @@ async function querySubgraphByFragments(
   const nft_fragments_per_query = parseInt((await config.getString('NFT_FRAGMENTS_PER_QUERY')) ?? '10')
   const entries = Array.from(nftIdsByAddressToCheck.entries())
   const result: Map<string, string[]> = new Map()
+
+  // Make multiple queries to graph as at most NFT_FRAGMENTS_PER_QUERY per time
+  let offset = 0
+  while (offset < entries.length) {
+    const slice = entries.slice(offset, offset + nft_fragments_per_query)
+    try {
+      const queryResult = await querySubgraph(theGraph, slice)
+      for (const { ownedNFTs, owner } of queryResult) {
+        result.set(owner, ownedNFTs)
+      }
+    } catch (error) {
+      // TODO: logger
+      console.log(error)
+    } finally {
+      offset += nft_fragments_per_query
+    }
+  }
+
+  return result
+}
+
+/*
+ * Return a set of the NFTs that are actually owned by the eth address, for every eth address.
+ * Receive a `querySubgraph` method to know how to do the query.
+ * Used to query NFTs following the standard ERC-721.
+ */
+async function querySubgraphByFragmentsExtended(
+  components: Pick<AppComponents, 'theGraph' | 'config'>,
+  nftIdsByAddressToCheck: Map<string, { urn: string; tokenId: string | undefined }[]>,
+  querySubgraph: (
+    theGraph: TheGraphComponent,
+    nftsToCheck: [string, { urn: string; tokenId: string | undefined }[]][]
+  ) => any
+): Promise<Map<string, { urn: string; tokenId: string | undefined }[]>> {
+  const { theGraph, config } = components
+  const nft_fragments_per_query = parseInt((await config.getString('NFT_FRAGMENTS_PER_QUERY')) ?? '10')
+  const entries = Array.from(nftIdsByAddressToCheck.entries())
+  const result: Map<string, { urn: string; tokenId: string }[]> = new Map()
 
   // Make multiple queries to graph as at most NFT_FRAGMENTS_PER_QUERY per time
   let offset = 0

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -19,3 +19,19 @@ export async function findAsync<T>(elements: T[], f: (e: T) => Promise<boolean>)
 
   return undefined
 }
+
+export function resolveUrn(urnString: string) {
+  const urnLength = urnString.split(':').length
+
+  if (urnLength === 7) {
+    const lastColonIndex = urnString.lastIndexOf(':')
+    const urnValue = urnString.slice(0, lastColonIndex)
+    return { urn: urnValue, tokenId: urnString.slice(lastColonIndex + 1) }
+  } else {
+    return { urn: urnString, tokenId: undefined }
+  }
+}
+
+export function isBaseWearable(wearable: string): boolean {
+  return wearable.includes('base-avatars')
+}

--- a/src/ports/ownership-checker/wearables-ownership-checker.ts
+++ b/src/ports/ownership-checker/wearables-ownership-checker.ts
@@ -1,35 +1,57 @@
 import { ISubgraphComponent } from '@well-known-components/thegraph-component'
-import { ownedNFTsByAddress } from '../../logic/ownership'
-import { AppComponents, NFTsOwnershipChecker } from '../../types'
+import { ownedExtendedNFTsByAddress } from '../../logic/ownership'
+import { AppComponents, ExtendedNFTsOwnershipChecker } from '../../types'
 import { runQuery, TheGraphComponent } from '../the-graph'
-import { fillCacheWithRecentlyCheckedWearables, getCachedNFTsAndPendingCheckNFTs } from '../../logic/cache'
-import { mergeMapIntoMap } from '../../logic/maps'
+import {
+  fillCacheWithRecentlyCheckedExtendedWearables,
+  getCachedNFTsAndPendingCheckExtendedNFTs
+} from '../../logic/cache'
+import { mergeMapIntoMapExtended } from '../../logic/maps'
+import { parseUrn, resolveUrn } from '../../logic/utils'
 
 export function createWearablesOwnershipChecker(
   components: Pick<AppComponents, 'metrics' | 'content' | 'theGraph' | 'config' | 'ownershipCaches'>
-): NFTsOwnershipChecker {
-  let ownedWearablesByAddress: Map<string, string[]> = new Map()
+): ExtendedNFTsOwnershipChecker {
+  let ownedWearablesByAddress: Map<string, { urn: string; tokenId: string | undefined }[]> = new Map()
   const cache = components.ownershipCaches.wearablesCache
 
-  function addNFTsForAddress(address: string, nfts: string[]) {
-    ownedWearablesByAddress.set(address, nfts)
+  async function addNFTsForAddress(address: string, nfts: string[]): Promise<void> {
+    const ownedNFTs: { urn: string; tokenId: string | undefined }[] = await Promise.all(
+      nfts.map(async (nft) => {
+        const parsedData = await parseUrn(nft)
+
+        if (
+          parsedData &&
+          (parsedData.type === 'blockchain-collection-v1-item' || parsedData.type === 'blockchain-collection-v2-item')
+        ) {
+          return resolveUrn(nft)
+        } else {
+          return { urn: nft, tokenId: undefined }
+        }
+      })
+    )
+
+    ownedWearablesByAddress.set(address, ownedNFTs)
   }
 
   async function checkNFTsOwnership() {
     // Check the cache before checking ownership in the blockchain
-    const { nftsToCheckByAddress, cachedOwnedNFTsByAddress } = getCachedNFTsAndPendingCheckNFTs(
+    const { nftsToCheckByAddress, cachedOwnedNFTsByAddress } = getCachedNFTsAndPendingCheckExtendedNFTs(
       ownedWearablesByAddress,
       cache
     )
 
     // Check ownership for the non-cached nfts
-    ownedWearablesByAddress = await ownedNFTsByAddress(components, nftsToCheckByAddress, queryWearablesSubgraph)
+    ownedWearablesByAddress = await ownedExtendedNFTsByAddress(components, nftsToCheckByAddress, queryWearablesSubgraph)
+
+    // Get unique nfts that were recently checked
+    ownedWearablesByAddress = getUniqueMatchingNFTs(nftsToCheckByAddress, ownedWearablesByAddress)
 
     // Traverse the already checked nfts to set the cache depending on its ownership
-    fillCacheWithRecentlyCheckedWearables(nftsToCheckByAddress, ownedWearablesByAddress, cache)
+    fillCacheWithRecentlyCheckedExtendedWearables(nftsToCheckByAddress, ownedWearablesByAddress, cache)
 
     // Merge cachedOwnedNFTsByAddress (contains the nfts which ownershipwas cached) into ownedWearablesByAddress (recently checked ownnership map)
-    mergeMapIntoMap(cachedOwnedNFTsByAddress, ownedWearablesByAddress)
+    mergeMapIntoMapExtended(cachedOwnedNFTsByAddress, ownedWearablesByAddress)
   }
 
   function getOwnedNFTsForAddress(address: string) {
@@ -45,22 +67,24 @@ export function createWearablesOwnershipChecker(
 
 async function queryWearablesSubgraph(
   theGraph: TheGraphComponent,
-  nftsToCheck: [string, string[]][]
-): Promise<{ owner: string; ownedNFTs: string[] }[]> {
+  nftsToCheck: [string, { urn: string; tokenId: string | undefined }[]][]
+): Promise<{ owner: string; ownedNFTs: { urn: string; tokenId: string | undefined }[] }[]> {
   const result = await checkForWearablesOwnership(theGraph, nftsToCheck)
   return result.map(({ urns, owner }) => ({ ownedNFTs: urns, owner }))
 }
 
-function splitWearablesByNetwork(wearableIdsToCheck: [string, string[]][]) {
-  const ethereum: [string, string[]][] = []
-  const matic: [string, string[]][] = []
+function splitWearablesByNetwork(wearableIdsToCheck: [string, { urn: string; tokenId: string | undefined }[]][]) {
+  const ethereum: [string, { urn: string; tokenId: string | undefined }[]][] = []
+  const matic: [string, { urn: string; tokenId: string | undefined }[]][] = []
 
   for (const [owner, urns] of wearableIdsToCheck) {
-    const ethUrns = urns.filter((urn) => urn.startsWith('urn:decentraland:ethereum'))
+    const ethUrns = urns.filter((urn) => urn.urn.startsWith('urn:decentraland:ethereum'))
     if (ethUrns.length > 0) {
       ethereum.push([owner, ethUrns])
     }
-    const maticUrns = urns.filter((urn) => urn.startsWith('urn:decentraland:matic'))
+    const maticUrns = urns.filter(
+      (urn) => urn.urn.startsWith('urn:decentraland:matic') || urn.urn.startsWith('urn:decentraland:mumbai')
+    )
     if (maticUrns.length > 0) {
       matic.push([owner, maticUrns])
     }
@@ -77,8 +101,8 @@ function splitWearablesByNetwork(wearableIdsToCheck: [string, string[]][]) {
  */
 async function checkForWearablesOwnership(
   theGraph: TheGraphComponent,
-  wearableIdsToCheck: [string, string[]][]
-): Promise<{ owner: string; urns: string[] }[]> {
+  wearableIdsToCheck: [string, { urn: string; tokenId: string | undefined }[]][]
+): Promise<{ owner: string; urns: { urn: string; tokenId: string | undefined }[] }[]> {
   const { ethereum, matic } = splitWearablesByNetwork(wearableIdsToCheck)
   const ethereumWearablesOwnersPromise = getOwnedWearables(ethereum, theGraph.ethereumCollectionsSubgraph)
   const maticWearablesOwnersPromise = getOwnedWearables(matic, theGraph.maticCollectionsSubgraph)
@@ -90,9 +114,9 @@ async function checkForWearablesOwnership(
 }
 
 async function getOwnedWearables(
-  wearableIdsToCheck: [string, string[]][],
+  wearableIdsToCheck: [string, { urn: string; tokenId: string | undefined }[]][],
   subgraph: ISubgraphComponent
-): Promise<{ owner: string; urns: string[] }[]> {
+): Promise<{ owner: string; urns: { urn: string; tokenId: string | undefined }[] }[]> {
   try {
     return getOwnersByWearable(wearableIdsToCheck, subgraph)
   } catch (error) {
@@ -103,50 +127,119 @@ async function getOwnedWearables(
 }
 
 async function getOwnersByWearable(
-  wearableIdsToCheck: [string, string[]][],
+  wearableIdsToCheck: [string, { urn: string; tokenId: string | undefined }[]][],
   subgraph: ISubgraphComponent
-): Promise<{ owner: string; urns: string[] }[]> {
+): Promise<{ owner: string; urns: { urn: string; tokenId: string | undefined }[] }[]> {
   // Build query for subgraph
   const filtered = wearableIdsToCheck.filter(([, urns]) => urns.length > 0)
   if (filtered.length > 0) {
     const subgraphQuery = `{` + filtered.map((query) => getWearablesFragment(query)).join('\n') + `}`
     // Run query
-    const queryResponse = await runQuery<Map<string, { urn: string }[]>>(subgraph, subgraphQuery, {})
+    const queryResponse = await runQuery<Map<string, { urn: string; tokenId: string }[]>>(subgraph, subgraphQuery, {})
 
-    // Transform the result to an array of { owner, urns }
+    // Transform the result to an array of { owner, urns: { urn, tokenId} }
     return Object.entries(queryResponse).map(([addressWithPrefix, wearables]) => ({
-      owner: addressWithPrefix.substring(1), // Remove the 'P' prefix added previously because the graph needs the fragment name to start with a letter
-      urns: wearables.map((urnObj: { urn: string }) => urnObj.urn)
+      owner: addressWithPrefix.substring(1), // Remove the 'P' prefix added previously
+      urns: wearables.map((urnObj: { urn: string; tokenId: string }) => ({
+        urn: urnObj.urn,
+        tokenId: urnObj.tokenId
+      }))
     }))
   }
 
   return wearableIdsToCheck.map(([owner]) => ({ owner, urns: [] }))
 }
 
-function getWearablesFragment([ethAddress, wearableIds]: [string, string[]]) {
-  const urnList = wearableIds.map((wearableId) => `"${wearableId}"`).join(',')
+function getWearablesFragment([ethAddress, wearableIds]: [string, { urn: string; tokenId: string | undefined }[]]) {
+  const urnList = wearableIds.map((wearableId) => `"${wearableId.urn}"`).join(',')
 
   // We need to add a 'P' prefix, because the graph needs the fragment name to start with a letter
   return `
         P${ethAddress}: nfts(where: { owner: "${ethAddress}", searchItemType_in: ["wearable_v1", "wearable_v2", "smart_wearable_v1", "emote_v1"], urn_in: [${urnList}] }, first: 1000) {
         urn
+        tokenId
         }
     `
 }
 
 function concatWearables(
-  ethereumWearablesOwners: { owner: string; urns: string[] }[],
-  maticWearablesOwners: { owner: string; urns: string[] }[]
+  ethereumWearablesOwners: { owner: string; urns: { urn: string; tokenId: string | undefined }[] }[],
+  maticWearablesOwners: { owner: string; urns: { urn: string; tokenId: string | undefined }[] }[]
 ) {
-  const allWearables: Map<string, string[]> = new Map<string, string[]>()
+  const allWearables: Map<string, { urn: string; tokenId: string | undefined }[]> = new Map<
+    string,
+    { urn: string; tokenId: string }[]
+  >()
 
-  ethereumWearablesOwners.forEach((a) => {
-    allWearables.set(a.owner, a.urns)
-  })
-  maticWearablesOwners.forEach((b) => {
-    const existingUrns = allWearables.get(b.owner) ?? []
-    allWearables.set(b.owner, existingUrns.concat(b.urns))
+  ;[...ethereumWearablesOwners, ...maticWearablesOwners].forEach(({ owner, urns }) => {
+    const existingUrns = allWearables.get(owner) ?? []
+    allWearables.set(owner, existingUrns.concat(urns))
   })
 
   return Array.from(allWearables.entries()).map(([owner, urns]) => ({ owner, urns }))
+}
+
+function getUniqueMatchingNFTs(
+  nftsToCheckByAddress: Map<
+    string,
+    {
+      urn: string
+      tokenId: string | undefined
+    }[]
+  >,
+  ownedWearablesByAddress: Map<
+    string,
+    {
+      urn: string
+      tokenId: string | undefined
+    }[]
+  >
+): Map<
+  string,
+  {
+    urn: string
+    tokenId: string | undefined
+  }[]
+> {
+  const resultMap: Map<
+    string,
+    {
+      urn: string
+      tokenId: string | undefined
+    }[]
+  > = new Map()
+
+  for (const [address, nftsToCheck] of nftsToCheckByAddress.entries()) {
+    // Retrieve the owned wearables for the same address
+    const ownedWearables = ownedWearablesByAddress.get(address) || []
+
+    // To store matched items
+    const matchedNFTs: {
+      urn: string
+      tokenId: string | undefined
+    }[] = []
+
+    for (const nft of nftsToCheck) {
+      // If tokenId is undefined
+      if (nft.tokenId === undefined) {
+        // Check for any owned wearable with the same urn
+        const owned = ownedWearables.find((o) => o.urn === nft.urn)
+        if (owned && !matchedNFTs.some((m) => m.urn === owned.urn)) {
+          matchedNFTs.push(owned)
+        }
+      } else {
+        // If tokenId is defined, check both urn and tokenId
+        const owned = ownedWearables.find((o) => o.urn === nft.urn && o.tokenId === nft.tokenId)
+        if (owned && !matchedNFTs.some((m) => m.urn === owned.urn && m.tokenId === owned.tokenId)) {
+          matchedNFTs.push(owned)
+        }
+      }
+    }
+
+    if (matchedNFTs.length > 0) {
+      resultMap.set(address, matchedNFTs)
+    }
+  }
+
+  return resultMap
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,6 +112,12 @@ export interface NFTsOwnershipChecker {
   getOwnedNFTsForAddress: (address: string) => string[]
 }
 
+export interface ExtendedNFTsOwnershipChecker {
+  addNFTsForAddress: (address: string, nfts: string[]) => Promise<void>
+  checkNFTsOwnership: () => Promise<void>
+  getOwnedNFTsForAddress: (address: string) => { urn: string; tokenId: string | undefined }[]
+}
+
 /**
  * Function used to fetch TheGraph
  * @public

--- a/test/integration/data/profiles-responses.ts
+++ b/test/integration/data/profiles-responses.ts
@@ -1,6 +1,6 @@
 import { EntityType } from '@dcl/schemas'
 
-export const profileEntityFull = {
+export const completeProfileEntityWithShortenedURNs = {
   version: 'v3',
   id: 'bafkreid2ltr77sewkzr4xz37pzyvcgzeljubecqworvsdbw7t5333h6q3a',
   type: EntityType.PROFILE,
@@ -36,6 +36,87 @@ export const profileEntityFull = {
             'urn:decentraland:matic:collections-v2:0x293d1ae40b28c39d7b013d4a1fe3c5a8c016bf19:1',
             'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_feet',
             'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_hand',
+            'urn:decentraland:matic:collections-thirdparty:ntr1-meta:ntr1-meta-1ef79e7b:98ac122c-523f-403f-9730-f09c992f386f',
+            'urn:decentraland:matic:collections-thirdparty:ntr1-meta:ntr1-meta-1ef79e7b:12341234-1234-3434-3434-f9dfde9f9393'
+          ],
+          emotes: [
+            {
+              slot: 0,
+              urn: 'urn:decentraland:mumbai:collections-v2:0x81028f51a57d1aa4a454ea7f281ad18575b2dc0b:0'
+            }
+          ],
+          snapshots: {
+            body: 'bafkreicilawwtbjyf6ahyzv64ssoamdm73rif75qncee5lv6j3a3352lua',
+            face256: 'bafkreigi3yrgdhvjr2cqzxvfztnsubnll2cfdioo4vfzu6o6vibwoag2ma'
+          },
+          eyes: {
+            color: {
+              r: 0.37109375,
+              g: 0.22265625,
+              b: 0.1953125,
+              a: 1
+            }
+          },
+          hair: {
+            color: {
+              r: 0.234375,
+              g: 0.12890625,
+              b: 0.04296875,
+              a: 1
+            }
+          },
+          skin: {
+            color: {
+              r: 0.94921875,
+              g: 0.76171875,
+              b: 0.6484375,
+              a: 1
+            }
+          }
+        },
+        interests: [],
+        hasConnectedWeb3: true
+      }
+    ]
+  }
+}
+
+export const completeProfileEntityWithExtendedURNs = {
+  version: 'v3',
+  id: 'bafkreid2ltr77sewkzr4xz37pzyvcgzeljubecqworvsdbw7t5333h6q3a',
+  type: EntityType.PROFILE,
+  timestamp: 1662137617154,
+  pointers: ['0x1'],
+  content: [
+    {
+      file: 'body.png',
+      hash: 'bafkreicilawwtbjyf6ahyzv64ssoamdm73rif75qncee5lv6j3a3352lua'
+    },
+    {
+      file: 'face256.png',
+      hash: 'bafkreigi3yrgdhvjr2cqzxvfztnsubnll2cfdioo4vfzu6o6vibwoag2ma'
+    }
+  ],
+  metadata: {
+    avatars: [
+      {
+        hasClaimedName: true,
+        name: 'cryptonico',
+        description: '',
+        tutorialStep: 256,
+        userId: '0x1',
+        email: '',
+        ethAddress: '0x1',
+        version: 30,
+        avatar: {
+          bodyShape: 'urn:decentraland:off-chain:base-avatars:BaseMale',
+          wearables: [
+            'urn:decentraland:off-chain:base-avatars:eyebrows_00',
+            'urn:decentraland:off-chain:base-avatars:short_hair',
+            'urn:decentraland:matic:collections-v2:0xa25c20f58ac447621a5f854067b857709cbd60eb:7:123',
+            'urn:decentraland:matic:collections-v2:0x293d1ae40b28c39d7b013d4a1fe3c5a8c016bf19:1:123',
+            'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_feet:123',
+            'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_hand:123',
             'urn:decentraland:matic:collections-thirdparty:ntr1-meta:ntr1-meta-1ef79e7b:98ac122c-523f-403f-9730-f09c992f386f',
             'urn:decentraland:matic:collections-thirdparty:ntr1-meta:ntr1-meta-1ef79e7b:12341234-1234-3434-3434-f9dfde9f9393'
           ],
@@ -142,7 +223,79 @@ export const profileEntityWithoutNFTs = {
   }
 }
 
-export const profileEntityTwoEthWearables = {
+export const profileEntityTwoEthWearablesExtended = {
+  version: 'v3',
+  id: 'bafkreid2ltr77sewkzr4xz37pzyvcgzeljubecqworvsdbw7t5333h6q3a',
+  type: EntityType.PROFILE,
+  timestamp: 1662137617154,
+  pointers: ['0x3'],
+  content: [
+    {
+      file: 'body.png',
+      hash: 'bafkreicilawwtbjyf6ahyzv64ssoamdm73rif75qncee5lv6j3a3352lua'
+    },
+    {
+      file: 'face256.png',
+      hash: 'bafkreigi3yrgdhvjr2cqzxvfztnsubnll2cfdioo4vfzu6o6vibwoag2ma'
+    }
+  ],
+  metadata: {
+    avatars: [
+      {
+        hasClaimedName: false,
+        name: 'cryptonico#e602',
+        description: '',
+        tutorialStep: 256,
+        userId: '0x3',
+        email: '',
+        ethAddress: '0x3',
+        version: 30,
+        avatar: {
+          bodyShape: 'urn:decentraland:off-chain:base-avatars:BaseMale',
+          wearables: [
+            'urn:decentraland:off-chain:base-avatars:eyebrows_00',
+            'urn:decentraland:off-chain:base-avatars:short_hair',
+            'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_feet:123',
+            'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_hand:123'
+          ],
+          snapshots: {
+            body: 'bafkreicilawwtbjyf6ahyzv64ssoamdm73rif75qncee5lv6j3a3352lua',
+            face256: 'bafkreigi3yrgdhvjr2cqzxvfztnsubnll2cfdioo4vfzu6o6vibwoag2ma'
+          },
+          eyes: {
+            color: {
+              r: 0.37109375,
+              g: 0.22265625,
+              b: 0.1953125,
+              a: 1
+            }
+          },
+          hair: {
+            color: {
+              r: 0.234375,
+              g: 0.12890625,
+              b: 0.04296875,
+              a: 1
+            }
+          },
+          skin: {
+            color: {
+              r: 0.94921875,
+              g: 0.76171875,
+              b: 0.6484375,
+              a: 1
+            }
+          }
+        },
+        interests: [],
+        unclaimedName: 'cryptonico',
+        hasConnectedWeb3: true
+      }
+    ]
+  }
+}
+
+export const profileEntityTwoEthWearablesShortened = {
   version: 'v3',
   id: 'bafkreid2ltr77sewkzr4xz37pzyvcgzeljubecqworvsdbw7t5333h6q3a',
   type: EntityType.PROFILE,
@@ -214,7 +367,79 @@ export const profileEntityTwoEthWearables = {
   }
 }
 
-export const profileEntityTwoMaticWearables = {
+export const profileEntityTwoMaticWearablesExtended = {
+  version: 'v3',
+  id: 'bafkreid2ltr77sewkzr4xz37pzyvcgzeljubecqworvsdbw7t5333h6q3a',
+  type: EntityType.PROFILE,
+  timestamp: 1662137617154,
+  pointers: ['0x4'],
+  content: [
+    {
+      file: 'body.png',
+      hash: 'bafkreicilawwtbjyf6ahyzv64ssoamdm73rif75qncee5lv6j3a3352lua'
+    },
+    {
+      file: 'face256.png',
+      hash: 'bafkreigi3yrgdhvjr2cqzxvfztnsubnll2cfdioo4vfzu6o6vibwoag2ma'
+    }
+  ],
+  metadata: {
+    avatars: [
+      {
+        hasClaimedName: false,
+        name: 'cryptonico#e602',
+        description: '',
+        tutorialStep: 256,
+        userId: '0x4',
+        email: '',
+        ethAddress: '0x4',
+        version: 30,
+        avatar: {
+          bodyShape: 'urn:decentraland:off-chain:base-avatars:BaseMale',
+          wearables: [
+            'urn:decentraland:off-chain:base-avatars:eyebrows_00',
+            'urn:decentraland:off-chain:base-avatars:short_hair',
+            'urn:decentraland:matic:collections-v2:0xa25c20f58ac447621a5f854067b857709cbd60eb:7:123',
+            'urn:decentraland:matic:collections-v2:0x293d1ae40b28c39d7b013d4a1fe3c5a8c016bf19:1:123'
+          ],
+          snapshots: {
+            body: 'bafkreicilawwtbjyf6ahyzv64ssoamdm73rif75qncee5lv6j3a3352lua',
+            face256: 'bafkreigi3yrgdhvjr2cqzxvfztnsubnll2cfdioo4vfzu6o6vibwoag2ma'
+          },
+          eyes: {
+            color: {
+              r: 0.37109375,
+              g: 0.22265625,
+              b: 0.1953125,
+              a: 1
+            }
+          },
+          hair: {
+            color: {
+              r: 0.234375,
+              g: 0.12890625,
+              b: 0.04296875,
+              a: 1
+            }
+          },
+          skin: {
+            color: {
+              r: 0.94921875,
+              g: 0.76171875,
+              b: 0.6484375,
+              a: 1
+            }
+          }
+        },
+        interests: [],
+        unclaimedName: 'cryptonico',
+        hasConnectedWeb3: true
+      }
+    ]
+  }
+}
+
+export const profileEntityTwoMaticWearablesShortened = {
   version: 'v3',
   id: 'bafkreid2ltr77sewkzr4xz37pzyvcgzeljubecqworvsdbw7t5333h6q3a',
   type: EntityType.PROFILE,
@@ -499,7 +724,82 @@ export const profileEntitySeveralTPWFromDifferentCollections = {
   }
 }
 
-export const profileEntityFullB = {
+export const profileEntityFullBExtended = {
+  version: 'v3',
+  id: 'bafkreid2ltr77sewkzr4xz37pzyvcgzeljubecqworvsdbw7t5333h6q3a',
+  type: EntityType.PROFILE,
+  timestamp: 1662137617154,
+  pointers: ['0x1b'],
+  content: [
+    {
+      file: 'body.png',
+      hash: 'bafkreicilawwtbjyf6ahyzv64ssoamdm73rif75qncee5lv6j3a3352lua'
+    },
+    {
+      file: 'face256.png',
+      hash: 'bafkreigi3yrgdhvjr2cqzxvfztnsubnll2cfdioo4vfzu6o6vibwoag2ma'
+    }
+  ],
+  metadata: {
+    avatars: [
+      {
+        hasClaimedName: true,
+        name: 'cryptonico',
+        description: '',
+        tutorialStep: 256,
+        userId: '0x1b',
+        email: '',
+        ethAddress: '0x1b',
+        version: 30,
+        avatar: {
+          bodyShape: 'urn:decentraland:off-chain:base-avatars:BaseMale',
+          wearables: [
+            'urn:decentraland:off-chain:base-avatars:eyebrows_00',
+            'urn:decentraland:off-chain:base-avatars:short_hair',
+            'urn:decentraland:matic:collections-v2:0xa25c20f58ac447621a5f854067b857709cbd60eb:7:123',
+            'urn:decentraland:matic:collections-v2:0x293d1ae40b28c39d7b013d4a1fe3c5a8c016bf19:1:123',
+            'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_feet:123',
+            'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_hand:123',
+            'urn:decentraland:matic:collections-thirdparty:ntr1-meta:ntr1-meta-1ef79e7b:98ac122c-523f-403f-9730-f09c992f386f',
+            'urn:decentraland:matic:collections-thirdparty:ntr1-meta:ntr1-meta-1ef79e7b:12341234-1234-3434-3434-f9dfde9f9393'
+          ],
+          snapshots: {
+            body: 'bafkreicilawwtbjyf6ahyzv64ssoamdm73rif75qncee5lv6j3a3352lua',
+            face256: 'bafkreigi3yrgdhvjr2cqzxvfztnsubnll2cfdioo4vfzu6o6vibwoag2ma'
+          },
+          eyes: {
+            color: {
+              r: 0.37109375,
+              g: 0.22265625,
+              b: 0.1953125,
+              a: 1
+            }
+          },
+          hair: {
+            color: {
+              r: 0.234375,
+              g: 0.12890625,
+              b: 0.04296875,
+              a: 1
+            }
+          },
+          skin: {
+            color: {
+              r: 0.94921875,
+              g: 0.76171875,
+              b: 0.6484375,
+              a: 1
+            }
+          }
+        },
+        interests: [],
+        hasConnectedWeb3: true
+      }
+    ]
+  }
+}
+
+export const profileEntityFullBShortened = {
   version: 'v3',
   id: 'bafkreid2ltr77sewkzr4xz37pzyvcgzeljubecqworvsdbw7t5333h6q3a',
   type: EntityType.PROFILE,
@@ -574,7 +874,82 @@ export const profileEntityFullB = {
   }
 }
 
-export const profileEntityFullAnother = {
+export const profileEntityFullAnotherExtended = {
+  version: 'v3',
+  id: 'an9d8fngnsd97sdfnsd9n0gsmw987rgsafdn8hsdtgyaerdhgah0rfg0ad9',
+  type: EntityType.PROFILE,
+  timestamp: 1662137617152,
+  pointers: ['0x8'],
+  content: [
+    {
+      file: 'body.png',
+      hash: 'bafkreicilawwtbjyf6ahyzv64ssoamdm73rif75qncee5lv6j3a3352lue'
+    },
+    {
+      file: 'face256.png',
+      hash: 'bafkreigi3yrgdhvjr2cqzxvfztnsubnll2cfdioo4vfzu6o6vibwoag2me'
+    }
+  ],
+  metadata: {
+    avatars: [
+      {
+        hasClaimedName: true,
+        name: 'testing',
+        description: '',
+        tutorialStep: 256,
+        userId: '0x8',
+        email: '',
+        ethAddress: '0x8',
+        version: 30,
+        avatar: {
+          bodyShape: 'urn:decentraland:off-chain:base-avatars:BaseFemale',
+          wearables: [
+            'urn:decentraland:off-chain:base-avatars:eyebrows_01',
+            'urn:decentraland:off-chain:base-avatars:long_hair',
+            'urn:decentraland:matic:collections-v2:0xa25c20f58ac447621a5f854067b857709cbd60eb:6:123',
+            'urn:decentraland:matic:collections-v2:0x293d1ae40b28c39d7b013d4a1fe3c5a8c016bf19:2:123',
+            'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_hat:123',
+            'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_shirt:123',
+            'urn:decentraland:matic:collections-thirdparty:ntr2-meta:ntr2-meta-123v289a:w3499wer-523f-403f-9730-f09c992f386f',
+            'urn:decentraland:matic:collections-thirdparty:ntr2-meta:ntr2-meta-123v289a:12341234-9876-3434-3434-f9dfde9f9393'
+          ],
+          snapshots: {
+            body: 'bafkreicilawwtbjyf6ahyzv64ssoamdm73rif75qncee5lv6j3a3352lue',
+            face256: 'bafkreigi3yrgdhvjr2cqzxvfztnsubnll2cfdioo4vfzu6o6vibwoag2me'
+          },
+          eyes: {
+            color: {
+              r: 0.37109375,
+              g: 0.22265625,
+              b: 0.1953125,
+              a: 1
+            }
+          },
+          hair: {
+            color: {
+              r: 0.234375,
+              g: 0.12890625,
+              b: 0.04296875,
+              a: 1
+            }
+          },
+          skin: {
+            color: {
+              r: 0.94921875,
+              g: 0.76171875,
+              b: 0.6484375,
+              a: 1
+            }
+          }
+        },
+        interests: [],
+        hasConnectedWeb3: true
+      }
+    ]
+  }
+}
+
+export const profileEntityFullAnotherShortened = {
   version: 'v3',
   id: 'an9d8fngnsd97sdfnsd9n0gsmw987rgsafdn8hsdtgyaerdhgah0rfg0ad9',
   type: EntityType.PROFILE,

--- a/test/integration/emotes-handler.spec.ts
+++ b/test/integration/emotes-handler.spec.ts
@@ -467,7 +467,7 @@ type ContentInfo = {
 function convertToDataModel(emotes: EmoteFromQuery[], contentInfo?: ContentInfo): OnChainEmoteResponse[] {
   return emotes.map((emote): OnChainEmoteResponse => {
     const individualData = {
-      id: emote.id,
+      id: `${emote.urn}:${emote.tokenId}`,
       tokenId: emote.tokenId,
       transferredAt: emote.transferredAt,
       price: emote.item.price
@@ -483,7 +483,9 @@ function convertToDataModel(emotes: EmoteFromQuery[], contentInfo?: ContentInfo)
       name: emote.metadata.emote.name,
       rarity,
       definition:
-        contentInfo?.includeDefinition && entity ? extractEmoteDefinitionFromEntity({ contentServerUrl }, entity) : undefined,
+        contentInfo?.includeDefinition && entity
+          ? extractEmoteDefinitionFromEntity({ contentServerUrl }, entity)
+          : undefined,
       entity: contentInfo?.includeEntity && entity ? entity : undefined
     }
   })

--- a/test/integration/explorer-handler.spec.ts
+++ b/test/integration/explorer-handler.spec.ts
@@ -120,7 +120,10 @@ testWithComponents(() => {
       }
     })
 
-    const convertedMixedBaseWearables = convertToMixedBaseWearableResponse(baseWearables, { entities, contentServerUrl })
+    const convertedMixedBaseWearables = convertToMixedBaseWearableResponse(baseWearables, {
+      entities,
+      contentServerUrl
+    })
     const convertedMixedOnChainWearables = convertToMixedOnChainWearableResponse(onChainWearables, {
       entities,
       contentServerUrl
@@ -132,6 +135,7 @@ testWithComponents(() => {
 
     const wallet = Wallet.generate().getAddressString()
     const r = await localFetch.fetch(`/explorer/${wallet}/wearables`)
+
     expect(r.status).toBe(200)
     expect(await r.json()).toEqual({
       elements: [
@@ -299,7 +303,7 @@ function convertToMixedOnChainWearableResponse(
 ): MixedWearableResponse[] {
   return wearables.map((wearable): MixedWearableResponse => {
     const individualData = {
-      id: wearable.id,
+      id: `${wearable.urn}:${wearable.tokenId}`,
       tokenId: wearable.tokenId,
       transferredAt: wearable.transferredAt,
       price: wearable.item.price

--- a/test/integration/outfits-controller.spec.ts
+++ b/test/integration/outfits-controller.spec.ts
@@ -1,0 +1,390 @@
+import { Entity, EntityType, Outfits } from '@dcl/schemas'
+import { test } from '../components'
+import sinon from 'sinon'
+
+const outfitsMetadataWithExtendedWearables: Outfits = {
+  outfits: [
+    {
+      slot: 1,
+      outfit: {
+        bodyShape: 'urn:decentraland:off-chain:base-avatars:BaseMale',
+        eyes: { color: { r: 0.23046875, g: 0.625, b: 0.3125 } },
+        hair: { color: { r: 0.35546875, g: 0.19140625, b: 0.05859375 } },
+        skin: { color: { r: 0.94921875, g: 0.76171875, b: 0.6484375 } },
+        wearables: [
+          'urn:decentraland:matic:collections-v2:0xf6f601efee04e74cecac02c8c5bdc8cc0fc1c721:0:123',
+          'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2:123',
+          'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet:123'
+        ]
+      }
+    },
+    {
+      slot: 5,
+      outfit: {
+        bodyShape: 'urn:decentraland:off-chain:base-avatars:BaseMale',
+        eyes: { color: { r: 0.23046875, g: 0.625, b: 0.3125 } },
+        hair: { color: { r: 0.35546875, g: 0.19140625, b: 0.05859375 } },
+        skin: { color: { r: 0.94921875, g: 0.76171875, b: 0.6484375 } },
+        wearables: [
+          'urn:decentraland:matic:collections-v2:0xf6f601efee04e74cecac02c8c5bdc8cc0fc1c721:0:123',
+          'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2:123',
+          'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet:123'
+        ]
+      }
+    }
+  ],
+  namesForExtraSlots: ['perro']
+}
+
+const outfitsMetadataWithShortenedWearables: Outfits = {
+  outfits: [
+    {
+      slot: 1,
+      outfit: {
+        bodyShape: 'urn:decentraland:off-chain:base-avatars:BaseMale',
+        eyes: { color: { r: 0.23046875, g: 0.625, b: 0.3125 } },
+        hair: { color: { r: 0.35546875, g: 0.19140625, b: 0.05859375 } },
+        skin: { color: { r: 0.94921875, g: 0.76171875, b: 0.6484375 } },
+        wearables: [
+          'urn:decentraland:matic:collections-v2:0xf6f601efee04e74cecac02c8c5bdc8cc0fc1c721:0',
+          'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2',
+          'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet'
+        ]
+      }
+    },
+    {
+      slot: 5,
+      outfit: {
+        bodyShape: 'urn:decentraland:off-chain:base-avatars:BaseMale',
+        eyes: { color: { r: 0.23046875, g: 0.625, b: 0.3125 } },
+        hair: { color: { r: 0.35546875, g: 0.19140625, b: 0.05859375 } },
+        skin: { color: { r: 0.94921875, g: 0.76171875, b: 0.6484375 } },
+        wearables: [
+          'urn:decentraland:matic:collections-v2:0xf6f601efee04e74cecac02c8c5bdc8cc0fc1c721:0',
+          'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2',
+          'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet'
+        ]
+      }
+    }
+  ],
+  namesForExtraSlots: ['perro']
+}
+
+const outfitsMetadataWithMixedWearables: Outfits = {
+  outfits: [
+    {
+      slot: 1,
+      outfit: {
+        bodyShape: 'urn:decentraland:off-chain:base-avatars:BaseMale',
+        eyes: { color: { r: 0.23046875, g: 0.625, b: 0.3125 } },
+        hair: { color: { r: 0.35546875, g: 0.19140625, b: 0.05859375 } },
+        skin: { color: { r: 0.94921875, g: 0.76171875, b: 0.6484375 } },
+        wearables: [
+          'urn:decentraland:matic:collections-v2:0xf6f601efee04e74cecac02c8c5bdc8cc0fc1c721:0',
+          'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2',
+          'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet'
+        ]
+      }
+    },
+    {
+      slot: 5,
+      outfit: {
+        bodyShape: 'urn:decentraland:off-chain:base-avatars:BaseMale',
+        eyes: { color: { r: 0.23046875, g: 0.625, b: 0.3125 } },
+        hair: { color: { r: 0.35546875, g: 0.19140625, b: 0.05859375 } },
+        skin: { color: { r: 0.94921875, g: 0.76171875, b: 0.6484375 } },
+        wearables: [
+          'urn:decentraland:matic:collections-v2:0xf6f601efee04e74cecac02c8c5bdc8cc0fc1c721:0:123',
+          'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2:123',
+          'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet:123'
+        ]
+      }
+    }
+  ],
+  namesForExtraSlots: ['perro']
+}
+
+test('integration tests for /outfits/{owner}', ({ components, stubComponents }) => {
+  it('should return whole outfit when shortened wearables are owned', async () => {
+    const { localFetch } = components
+    const { theGraph, fetch, content } = stubComponents
+    const address = '0x1'
+
+    const outfitsEntity: Entity = {
+      id: 'entityId',
+      version: 'v3',
+      type: EntityType.OUTFITS,
+      pointers: ['address:outfits'],
+      timestamp: 123,
+      metadata: outfitsMetadataWithShortenedWearables,
+      content: []
+    }
+
+    content.fetchEntitiesByPointers.withArgs([`${address}:outfits`]).resolves(await Promise.all([outfitsEntity]))
+    theGraph.ethereumCollectionsSubgraph.query = sinon
+      .stub()
+      .withArgs(sinon.match.string, sinon.match.object)
+      .resolves({
+        P0x1: [{ urn: 'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet', tokenId: '123' }]
+      })
+    theGraph.maticCollectionsSubgraph.query = sinon
+      .stub()
+      .withArgs(sinon.match.string, sinon.match.object)
+      .resolves({
+        P0x1: [
+          { urn: 'urn:decentraland:matic:collections-v2:0xf6f601efee04e74cecac02c8c5bdc8cc0fc1c721:0', tokenId: '123' },
+          { urn: 'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2', tokenId: '123' }
+        ]
+      })
+    theGraph.ensSubgraph.query = sinon.stub().withArgs(sinon.match.string, sinon.match.object).resolves({ P0x1: [] })
+
+    const response = await localFetch.fetch(`/outfits/${address}`)
+    const responseAsObject = await response.json()
+
+    expect(response.status).toEqual(200)
+    sinon.assert.calledOnceWithMatch(content.fetchEntitiesByPointers, [`${address}:outfits`])
+    expect(responseAsObject).toEqual(outfitsEntity)
+  })
+})
+
+test('integration tests for /outfits/{owner}', ({ components, stubComponents }) => {
+  it('should return whole outfit when extended wearables are owned', async () => {
+    const { localFetch } = components
+    const { theGraph, fetch, content } = stubComponents
+    const address = '0x1'
+
+    const outfitsEntity: Entity = {
+      id: 'entityId',
+      version: 'v3',
+      type: EntityType.OUTFITS,
+      pointers: ['address:outfits'],
+      timestamp: 123,
+      metadata: outfitsMetadataWithExtendedWearables,
+      content: []
+    }
+
+    content.fetchEntitiesByPointers.withArgs([`${address}:outfits`]).resolves(await Promise.all([outfitsEntity]))
+    theGraph.ethereumCollectionsSubgraph.query = sinon
+      .stub()
+      .withArgs(sinon.match.string, sinon.match.object)
+      .resolves({
+        P0x1: [{ urn: 'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet', tokenId: '123' }]
+      })
+    theGraph.maticCollectionsSubgraph.query = sinon
+      .stub()
+      .withArgs(sinon.match.string, sinon.match.object)
+      .resolves({
+        P0x1: [
+          { urn: 'urn:decentraland:matic:collections-v2:0xf6f601efee04e74cecac02c8c5bdc8cc0fc1c721:0', tokenId: '123' },
+          { urn: 'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2', tokenId: '123' }
+        ]
+      })
+    theGraph.ensSubgraph.query = sinon.stub().withArgs(sinon.match.string, sinon.match.object).resolves({ P0x1: [] })
+
+    const response = await localFetch.fetch(`/outfits/${address}`)
+    const responseAsObject = await response.json()
+
+    expect(response.status).toEqual(200)
+    sinon.assert.calledOnceWithMatch(content.fetchEntitiesByPointers, [`${address}:outfits`])
+    expect(responseAsObject).toEqual(outfitsEntity)
+  })
+})
+
+test('integration tests for /outfits/{owner}', ({ components, stubComponents }) => {
+  it('should return whole outfit when mixed wearables (extended and shortened) are owned', async () => {
+    const { localFetch } = components
+    const { theGraph, fetch, content } = stubComponents
+    const address = '0x1'
+
+    const outfitsEntity: Entity = {
+      id: 'entityId',
+      version: 'v3',
+      type: EntityType.OUTFITS,
+      pointers: ['address:outfits'],
+      timestamp: 123,
+      metadata: outfitsMetadataWithMixedWearables,
+      content: []
+    }
+
+    content.fetchEntitiesByPointers.withArgs([`${address}:outfits`]).resolves(await Promise.all([outfitsEntity]))
+    theGraph.ethereumCollectionsSubgraph.query = sinon
+      .stub()
+      .withArgs(sinon.match.string, sinon.match.object)
+      .resolves({
+        P0x1: [{ urn: 'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet', tokenId: '123' }]
+      })
+    theGraph.maticCollectionsSubgraph.query = sinon
+      .stub()
+      .withArgs(sinon.match.string, sinon.match.object)
+      .resolves({
+        P0x1: [
+          { urn: 'urn:decentraland:matic:collections-v2:0xf6f601efee04e74cecac02c8c5bdc8cc0fc1c721:0', tokenId: '123' },
+          { urn: 'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2', tokenId: '123' }
+        ]
+      })
+    theGraph.ensSubgraph.query = sinon.stub().withArgs(sinon.match.string, sinon.match.object).resolves({ P0x1: [] })
+
+    const response = await localFetch.fetch(`/outfits/${address}`)
+    const responseAsObject = await response.json()
+
+    expect(response.status).toEqual(200)
+    sinon.assert.calledOnceWithMatch(content.fetchEntitiesByPointers, [`${address}:outfits`])
+    expect(responseAsObject).toEqual(outfitsEntity)
+  })
+})
+
+test('integration tests for /outfits/{owner}', ({ components, stubComponents }) => {
+  it('should return whole outfit containing extended wearables urn when shortened wearables owned are passed and erc721 query param is sent', async () => {
+    const { localFetch } = components
+    const { theGraph, fetch, content } = stubComponents
+    const address = '0x1'
+
+    const outfitsEntity: Entity = {
+      id: 'entityId',
+      version: 'v3',
+      type: EntityType.OUTFITS,
+      pointers: ['address:outfits'],
+      timestamp: 123,
+      metadata: outfitsMetadataWithShortenedWearables,
+      content: []
+    }
+
+    const expectedOutfitsEntity: Entity = {
+      id: 'entityId',
+      version: 'v3',
+      type: EntityType.OUTFITS,
+      pointers: ['address:outfits'],
+      timestamp: 123,
+      metadata: outfitsMetadataWithExtendedWearables,
+      content: []
+    }
+
+    content.fetchEntitiesByPointers.withArgs([`${address}:outfits`]).resolves(await Promise.all([outfitsEntity]))
+    theGraph.ethereumCollectionsSubgraph.query = sinon
+      .stub()
+      .withArgs(sinon.match.string, sinon.match.object)
+      .resolves({
+        P0x1: [{ urn: 'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet', tokenId: '123' }]
+      })
+    theGraph.maticCollectionsSubgraph.query = sinon
+      .stub()
+      .withArgs(sinon.match.string, sinon.match.object)
+      .resolves({
+        P0x1: [
+          { urn: 'urn:decentraland:matic:collections-v2:0xf6f601efee04e74cecac02c8c5bdc8cc0fc1c721:0', tokenId: '123' },
+          { urn: 'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2', tokenId: '123' }
+        ]
+      })
+    theGraph.ensSubgraph.query = sinon.stub().withArgs(sinon.match.string, sinon.match.object).resolves({ P0x1: [] })
+
+    const response = await localFetch.fetch(`/outfits/${address}?erc721`)
+    const responseAsObject = await response.json()
+
+    expect(response.status).toEqual(200)
+    sinon.assert.calledOnceWithMatch(content.fetchEntitiesByPointers, [`${address}:outfits`])
+    expect(responseAsObject).toEqual(expectedOutfitsEntity)
+  })
+})
+
+test('integration tests for /outfits/{owner}', ({ components, stubComponents }) => {
+  it('CUSTOM CASE: should return whole outfit containing a single shortened urn + base wearables when shortened wearables owned are passed', async () => {
+    const { localFetch } = components
+    const { theGraph, fetch, content } = stubComponents
+    const address = '0x1'
+
+    const outfitsEntity: Entity = {
+      id: 'entityId',
+      version: 'v3',
+      type: EntityType.OUTFITS,
+      pointers: ['address:outfits'],
+      timestamp: 123,
+      metadata: {
+        outfits: [
+          {
+            slot: 0,
+            outfit: {
+              bodyShape: 'urn:decentraland:off-chain:base-avatars:BaseMale',
+              eyes: { color: { r: 0.23046875, g: 0.625, b: 0.3125 } },
+              hair: { color: { r: 0.35546875, g: 0.19140625, b: 0.05859375 } },
+              skin: { color: { r: 0.94921875, g: 0.76171875, b: 0.6484375 } },
+              wearables: [
+                'urn:decentraland:off-chain:base-avatars:moptop',
+                'urn:decentraland:off-chain:base-avatars:f_eyes_05',
+                'urn:decentraland:off-chain:base-avatars:mouth_07',
+                'urn:decentraland:off-chain:base-avatars:old_mustache_beard',
+                'urn:decentraland:off-chain:base-avatars:basketball_shorts',
+                'urn:decentraland:off-chain:base-avatars:eyebrows_12',
+                'urn:decentraland:matic:collections-v2:0x26ea2f6a7273a2f28b410406d1c13ff7d4c9a162:6',
+                'urn:decentraland:off-chain:base-avatars:bear_slippers',
+                'urn:decentraland:off-chain:base-avatars:black_sun_glasses'
+              ]
+            }
+          }
+        ],
+        namesForExtraSlots: []
+      },
+      content: []
+    }
+
+    const expectedOutfitsEntity: Entity = {
+      id: 'entityId',
+      version: 'v3',
+      type: EntityType.OUTFITS,
+      pointers: ['address:outfits'],
+      timestamp: 123,
+      metadata: {
+        outfits: [
+          {
+            slot: 0,
+            outfit: {
+              bodyShape: 'urn:decentraland:off-chain:base-avatars:BaseMale',
+              eyes: { color: { r: 0.23046875, g: 0.625, b: 0.3125 } },
+              hair: { color: { r: 0.35546875, g: 0.19140625, b: 0.05859375 } },
+              skin: { color: { r: 0.94921875, g: 0.76171875, b: 0.6484375 } },
+              wearables: [
+                'urn:decentraland:off-chain:base-avatars:moptop',
+                'urn:decentraland:off-chain:base-avatars:f_eyes_05',
+                'urn:decentraland:off-chain:base-avatars:mouth_07',
+                'urn:decentraland:off-chain:base-avatars:old_mustache_beard',
+                'urn:decentraland:off-chain:base-avatars:basketball_shorts',
+                'urn:decentraland:off-chain:base-avatars:eyebrows_12',
+                'urn:decentraland:matic:collections-v2:0x26ea2f6a7273a2f28b410406d1c13ff7d4c9a162:6',
+                'urn:decentraland:off-chain:base-avatars:bear_slippers',
+                'urn:decentraland:off-chain:base-avatars:black_sun_glasses'
+              ]
+            }
+          }
+        ],
+        namesForExtraSlots: []
+      },
+      content: []
+    }
+
+    content.fetchEntitiesByPointers.withArgs([`${address}:outfits`]).resolves(await Promise.all([outfitsEntity]))
+    theGraph.ethereumCollectionsSubgraph.query = sinon
+      .stub()
+      .withArgs(sinon.match.string, sinon.match.object)
+      .resolves({
+        P0x1: []
+      })
+    theGraph.maticCollectionsSubgraph.query = sinon
+      .stub()
+      .withArgs(sinon.match.string, sinon.match.object)
+      .resolves({
+        P0x1: [
+          {
+            urn: 'urn:decentraland:matic:collections-v2:0x26ea2f6a7273a2f28b410406d1c13ff7d4c9a162:6',
+            tokenId: '631873750011343120187508166102022593913370572403294667525865865549'
+          }
+        ]
+      })
+    theGraph.ensSubgraph.query = sinon.stub().withArgs(sinon.match.string, sinon.match.object).resolves({ P0x1: [] })
+
+    const response = await localFetch.fetch(`/outfits/${address}`)
+    const responseAsObject = await response.json()
+
+    expect(response.status).toEqual(200)
+    sinon.assert.calledOnceWithMatch(content.fetchEntitiesByPointers, [`${address}:outfits`])
+    expect(responseAsObject).toMatchObject(expectedOutfitsEntity)
+  })
+})

--- a/test/integration/profile-controller-extended.spec.ts
+++ b/test/integration/profile-controller-extended.spec.ts
@@ -1,0 +1,104 @@
+import { test } from '../components'
+import { Response } from 'node-fetch'
+import sinon from 'sinon'
+import { completeProfileEntityWithExtendedURNs, tpwResolverResponseFull } from './data/profiles-responses'
+
+test('integration tests for /profile/{id}?erc721', function ({ components, stubComponents }) {
+  it('calling with a single profile address, owning everything claimed', async () => {
+    const { localFetch } = components
+    const { theGraph, fetch, content } = stubComponents
+    const address = '0x1'
+
+    content.fetchEntitiesByPointers
+      .withArgs([address])
+      .resolves(await Promise.all([completeProfileEntityWithExtendedURNs]))
+    const wearablesQuery =
+      '{\n        P0x1: nfts(where: { owner: "0x1", searchItemType_in: ["wearable_v1", "wearable_v2", "smart_wearable_v1", "emote_v1"], urn_in: ["urn:decentraland:matic:collections-v2:0xa25c20f58ac447621a5f854067b857709cbd60eb:7","urn:decentraland:matic:collections-v2:0x293d1ae40b28c39d7b013d4a1fe3c5a8c016bf19:1","urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_feet","urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_hand","urn:decentraland:matic:collections-thirdparty:ntr1-meta:ntr1-meta-1ef79e7b:98ac122c-523f-403f-9730-f09c992f386f","urn:decentraland:matic:collections-thirdparty:ntr1-meta:ntr1-meta-1ef79e7b:12341234-1234-3434-3434-f9dfde9f9393"] }, first: 1000) {\n        urn\n        }\n    }'
+    theGraph.ethereumCollectionsSubgraph.query = sinon
+      .stub()
+      .withArgs(wearablesQuery, {})
+      .resolves({
+        P0x1: [
+          { urn: 'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_feet', tokenId: '123' },
+          { urn: 'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_hand', tokenId: '123' }
+        ]
+      })
+    theGraph.maticCollectionsSubgraph.query = sinon
+      .stub()
+      .withArgs(wearablesQuery, {})
+      .resolves({
+        P0x1: [
+          { urn: 'urn:decentraland:matic:collections-v2:0xa25c20f58ac447621a5f854067b857709cbd60eb:7', tokenId: '123' },
+          { urn: 'urn:decentraland:matic:collections-v2:0x293d1ae40b28c39d7b013d4a1fe3c5a8c016bf19:1', tokenId: '123' }
+        ]
+      })
+
+    const namesQuery =
+      '{\n      P0x1: nfts(where: { owner: "0x1", category: ens, name_in: ["cryptonico"] }, first: 1000) {\n        name\n      }\n    }'
+    theGraph.ensSubgraph.query = sinon
+      .stub()
+      .withArgs(namesQuery, {})
+      .resolves({ P0x1: [{ name: 'cryptonico' }] })
+
+    jest.spyOn(components.thirdPartyProvidersStorage, 'getAll').mockResolvedValue([
+      {
+        id: 'urn:decentraland:matic:collections-thirdparty:ntr1-meta',
+        resolver: 'https://api.swappable.io/api/v1',
+        metadata: {
+          thirdParty: {
+            name: 'test',
+            description: 'test'
+          }
+        }
+      }
+    ])
+    fetch.fetch
+      .withArgs('https://api.swappable.io/api/v1/registry/ntr1-meta/address/0x1/assets')
+      .onCall(0)
+      .resolves(new Response(JSON.stringify(tpwResolverResponseFull)))
+      .onCall(1)
+      .resolves(new Response(JSON.stringify(tpwResolverResponseFull)))
+
+    const response = await localFetch.fetch(`/profiles/${address}?erc721`)
+
+    sinon.assert.calledOnceWithMatch(content.fetchEntitiesByPointers, [address])
+
+    expect(response.status).toEqual(200)
+    const responseText = await response.text()
+    const responseObj = JSON.parse(responseText)
+    expect(responseObj.avatars.length).toEqual(1)
+    expect(responseObj.avatars?.[0].hasClaimedName).toEqual(true)
+    expect(responseObj.avatars?.[0].ethAddress).toEqual('0x1')
+    expect(responseObj.avatars?.[0].name).toEqual('cryptonico')
+    expect(responseObj.avatars?.[0].unclaimedName).toBeUndefined()
+    expect(responseObj.avatars?.[0].avatar.bodyShape).toEqual('urn:decentraland:off-chain:base-avatars:BaseMale')
+    expect(responseObj.avatars?.[0].avatar.snapshots.body).toEqual(
+      'https://peer.decentraland.org/content/contents/bafkreicilawwtbjyf6ahyzv64ssoamdm73rif75qncee5lv6j3a3352lua'
+    )
+    expect(responseObj.avatars?.[0].avatar.snapshots.face256).toEqual(
+      'https://peer.decentraland.org/content/contents/bafkreigi3yrgdhvjr2cqzxvfztnsubnll2cfdioo4vfzu6o6vibwoag2ma'
+    )
+
+    expect(responseObj.avatars?.[0].avatar.wearables.length).toEqual(8)
+    expect(responseObj.avatars?.[0].avatar.wearables).toContain('urn:decentraland:off-chain:base-avatars:eyebrows_00')
+    expect(responseObj.avatars?.[0].avatar.wearables).toContain('urn:decentraland:off-chain:base-avatars:short_hair')
+    expect(responseObj.avatars?.[0].avatar.wearables).toContain(
+      'urn:decentraland:matic:collections-v2:0xa25c20f58ac447621a5f854067b857709cbd60eb:7:123'
+    )
+    expect(responseObj.avatars?.[0].avatar.wearables).toContain(
+      'urn:decentraland:matic:collections-v2:0x293d1ae40b28c39d7b013d4a1fe3c5a8c016bf19:1:123'
+    )
+    expect(responseObj.avatars?.[0].avatar.wearables).toContain(
+      'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_feet:123'
+    )
+    expect(responseObj.avatars?.[0].avatar.wearables).toContain(
+      'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_feet:123'
+    )
+    expect(responseObj.avatars?.[0].avatar.wearables).toContain(
+      'urn:decentraland:matic:collections-thirdparty:ntr1-meta:ntr1-meta-1ef79e7b:98ac122c-523f-403f-9730-f09c992f386f'
+    )
+    expect(responseObj.avatars?.[0].avatar.wearables).toContain(
+      'urn:decentraland:matic:collections-thirdparty:ntr1-meta:ntr1-meta-1ef79e7b:12341234-1234-3434-3434-f9dfde9f9393'
+    )
+  })
+})

--- a/test/integration/profile-controller.spec.ts
+++ b/test/integration/profile-controller.spec.ts
@@ -1,7 +1,11 @@
 import { test } from '../components'
 import { Response } from 'node-fetch'
 import sinon from 'sinon'
-import { profileEntityFull, tpwResolverResponseFull } from './data/profiles-responses'
+import {
+  completeProfileEntityWithExtendedURNs,
+  completeProfileEntityWithShortenedURNs,
+  tpwResolverResponseFull
+} from './data/profiles-responses'
 
 test('integration tests for /profile/{id}', function ({ components, stubComponents }) {
   it('calling with a single profile address, owning everything claimed', async () => {
@@ -9,7 +13,9 @@ test('integration tests for /profile/{id}', function ({ components, stubComponen
     const { theGraph, fetch, content } = stubComponents
     const address = '0x1'
 
-    content.fetchEntitiesByPointers.withArgs([address]).resolves(await Promise.all([profileEntityFull]))
+    content.fetchEntitiesByPointers
+      .withArgs([address])
+      .resolves(await Promise.all([completeProfileEntityWithShortenedURNs]))
     const wearablesQuery =
       '{\n        P0x1: nfts(where: { owner: "0x1", searchItemType_in: ["wearable_v1", "wearable_v2", "smart_wearable_v1", "emote_v1"], urn_in: ["urn:decentraland:matic:collections-v2:0xa25c20f58ac447621a5f854067b857709cbd60eb:7","urn:decentraland:matic:collections-v2:0x293d1ae40b28c39d7b013d4a1fe3c5a8c016bf19:1","urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_feet","urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_hand","urn:decentraland:matic:collections-thirdparty:ntr1-meta:ntr1-meta-1ef79e7b:98ac122c-523f-403f-9730-f09c992f386f","urn:decentraland:matic:collections-thirdparty:ntr1-meta:ntr1-meta-1ef79e7b:12341234-1234-3434-3434-f9dfde9f9393"] }, first: 1000) {\n        urn\n        }\n    }'
     theGraph.ethereumCollectionsSubgraph.query = sinon
@@ -17,8 +23,8 @@ test('integration tests for /profile/{id}', function ({ components, stubComponen
       .withArgs(wearablesQuery, {})
       .resolves({
         P0x1: [
-          { urn: 'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_feet' },
-          { urn: 'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_hand' }
+          { urn: 'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_feet', tokenId: '123' },
+          { urn: 'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_hand', tokenId: '123' }
         ]
       })
     theGraph.maticCollectionsSubgraph.query = sinon
@@ -26,8 +32,96 @@ test('integration tests for /profile/{id}', function ({ components, stubComponen
       .withArgs(wearablesQuery, {})
       .resolves({
         P0x1: [
-          { urn: 'urn:decentraland:matic:collections-v2:0xa25c20f58ac447621a5f854067b857709cbd60eb:7' },
-          { urn: 'urn:decentraland:matic:collections-v2:0x293d1ae40b28c39d7b013d4a1fe3c5a8c016bf19:1' }
+          { urn: 'urn:decentraland:matic:collections-v2:0xa25c20f58ac447621a5f854067b857709cbd60eb:7', tokenId: '123' },
+          { urn: 'urn:decentraland:matic:collections-v2:0x293d1ae40b28c39d7b013d4a1fe3c5a8c016bf19:1', tokenId: '123' }
+        ]
+      })
+
+    const namesQuery =
+      '{\n      P0x1: nfts(where: { owner: "0x1", category: ens, name_in: ["cryptonico"] }, first: 1000) {\n        name\n      }\n    }'
+    theGraph.ensSubgraph.query = sinon
+      .stub()
+      .withArgs(namesQuery, {})
+      .resolves({ P0x1: [{ name: 'cryptonico' }] })
+
+    jest.spyOn(components.thirdPartyProvidersStorage, 'getAll').mockResolvedValue([
+      {
+        id: 'urn:decentraland:matic:collections-thirdparty:ntr1-meta',
+        resolver: 'https://api.swappable.io/api/v1',
+        metadata: {
+          thirdParty: {
+            name: 'test',
+            description: 'test'
+          }
+        }
+      }
+    ])
+    fetch.fetch
+      .withArgs('https://api.swappable.io/api/v1/registry/ntr1-meta/address/0x1/assets')
+      .onCall(0)
+      .resolves(new Response(JSON.stringify(tpwResolverResponseFull)))
+      .onCall(1)
+      .resolves(new Response(JSON.stringify(tpwResolverResponseFull)))
+
+    const response = await localFetch.fetch(`/profiles/${address}`)
+
+    sinon.assert.calledOnceWithMatch(content.fetchEntitiesByPointers, [address])
+
+    expect(response.status).toEqual(200)
+    const responseText = await response.text()
+    const responseObj = JSON.parse(responseText)
+
+    expect(responseObj.avatars?.[0].avatar.wearables.length).toEqual(8)
+    expect(responseObj.avatars?.[0].avatar.wearables).toContain('urn:decentraland:off-chain:base-avatars:eyebrows_00')
+    expect(responseObj.avatars?.[0].avatar.wearables).toContain('urn:decentraland:off-chain:base-avatars:short_hair')
+    expect(responseObj.avatars?.[0].avatar.wearables).toContain(
+      'urn:decentraland:matic:collections-v2:0xa25c20f58ac447621a5f854067b857709cbd60eb:7'
+    )
+    expect(responseObj.avatars?.[0].avatar.wearables).toContain(
+      'urn:decentraland:matic:collections-v2:0x293d1ae40b28c39d7b013d4a1fe3c5a8c016bf19:1'
+    )
+    expect(responseObj.avatars?.[0].avatar.wearables).toContain(
+      'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_feet'
+    )
+    expect(responseObj.avatars?.[0].avatar.wearables).toContain(
+      'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_feet'
+    )
+    expect(responseObj.avatars?.[0].avatar.wearables).toContain(
+      'urn:decentraland:matic:collections-thirdparty:ntr1-meta:ntr1-meta-1ef79e7b:98ac122c-523f-403f-9730-f09c992f386f'
+    )
+    expect(responseObj.avatars?.[0].avatar.wearables).toContain(
+      'urn:decentraland:matic:collections-thirdparty:ntr1-meta:ntr1-meta-1ef79e7b:12341234-1234-3434-3434-f9dfde9f9393'
+    )
+  })
+})
+
+test('integration tests for /profile/{id}', function ({ components, stubComponents }) {
+  it('calling with a single profile address, owning everything claimed', async () => {
+    const { localFetch } = components
+    const { theGraph, fetch, content } = stubComponents
+    const address = '0x1'
+
+    content.fetchEntitiesByPointers
+      .withArgs([address])
+      .resolves(await Promise.all([completeProfileEntityWithExtendedURNs]))
+    const wearablesQuery =
+      '{\n        P0x1: nfts(where: { owner: "0x1", searchItemType_in: ["wearable_v1", "wearable_v2", "smart_wearable_v1", "emote_v1"], urn_in: ["urn:decentraland:matic:collections-v2:0xa25c20f58ac447621a5f854067b857709cbd60eb:7","urn:decentraland:matic:collections-v2:0x293d1ae40b28c39d7b013d4a1fe3c5a8c016bf19:1","urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_feet","urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_hand","urn:decentraland:matic:collections-thirdparty:ntr1-meta:ntr1-meta-1ef79e7b:98ac122c-523f-403f-9730-f09c992f386f","urn:decentraland:matic:collections-thirdparty:ntr1-meta:ntr1-meta-1ef79e7b:12341234-1234-3434-3434-f9dfde9f9393"] }, first: 1000) {\n        urn\n        }\n    }'
+    theGraph.ethereumCollectionsSubgraph.query = sinon
+      .stub()
+      .withArgs(wearablesQuery, {})
+      .resolves({
+        P0x1: [
+          { urn: 'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_feet', tokenId: '123' },
+          { urn: 'urn:decentraland:ethereum:collections-v1:ethermon_wearables:ethermon_hand', tokenId: '123' }
+        ]
+      })
+    theGraph.maticCollectionsSubgraph.query = sinon
+      .stub()
+      .withArgs(wearablesQuery, {})
+      .resolves({
+        P0x1: [
+          { urn: 'urn:decentraland:matic:collections-v2:0xa25c20f58ac447621a5f854067b857709cbd60eb:7', tokenId: '123' },
+          { urn: 'urn:decentraland:matic:collections-v2:0x293d1ae40b28c39d7b013d4a1fe3c5a8c016bf19:1', tokenId: '123' }
         ]
       })
 
@@ -76,6 +170,7 @@ test('integration tests for /profile/{id}', function ({ components, stubComponen
     expect(responseObj.avatars?.[0].avatar.snapshots.face256).toEqual(
       'https://peer.decentraland.org/content/contents/bafkreigi3yrgdhvjr2cqzxvfztnsubnll2cfdioo4vfzu6o6vibwoag2ma'
     )
+
     expect(responseObj.avatars?.[0].avatar.wearables.length).toEqual(8)
     expect(responseObj.avatars?.[0].avatar.wearables).toContain('urn:decentraland:off-chain:base-avatars:eyebrows_00')
     expect(responseObj.avatars?.[0].avatar.wearables).toContain('urn:decentraland:off-chain:base-avatars:short_hair')

--- a/test/integration/wearables-handler.spec.ts
+++ b/test/integration/wearables-handler.spec.ts
@@ -113,7 +113,9 @@ test('wearables-handler: GET /users/:address/wearables should', function ({ comp
 
     expect(r.status).toBe(200)
     expect(await r.json()).toEqual({
-      elements: [...convertToDataModel(wearables, { entities, contentServerUrl, includeDefinition: true })].sort(rarest),
+      elements: [...convertToDataModel(wearables, { entities, contentServerUrl, includeDefinition: true })].sort(
+        rarest
+      ),
       pageNum: 1,
       pageSize: 100,
       totalAmount: 2
@@ -156,7 +158,9 @@ test('wearables-handler: GET /users/:address/wearables should', function ({ comp
 
     expect(r.status).toBe(200)
     expect(await r.json()).toEqual({
-      elements: [...convertToDataModel(wearables, { entities, contentServerUrl, includeDefinition: true })].sort(rarest),
+      elements: [...convertToDataModel(wearables, { entities, contentServerUrl, includeDefinition: true })].sort(
+        rarest
+      ),
       pageNum: 1,
       pageSize: 100,
       totalAmount: 2
@@ -628,7 +632,7 @@ type ContentInfo = {
 function convertToDataModel(wearables: WearableFromQuery[], contentInfo?: ContentInfo): OnChainWearableResponse[] {
   return wearables.map((wearable): OnChainWearableResponse => {
     const individualData = {
-      id: wearable.id,
+      id: `${wearable.urn}:${wearable.tokenId}`,
       tokenId: wearable.tokenId,
       transferredAt: wearable.transferredAt,
       price: wearable.item.price
@@ -644,7 +648,9 @@ function convertToDataModel(wearables: WearableFromQuery[], contentInfo?: Conten
       category: wearable.metadata.wearable.category,
       name: wearable.metadata.wearable.name,
       definition:
-        contentInfo?.includeDefinition && entity ? extractWearableDefinitionFromEntity({ contentServerUrl }, entity) : undefined,
+        contentInfo?.includeDefinition && entity
+          ? extractWearableDefinitionFromEntity({ contentServerUrl }, entity)
+          : undefined,
       entity: contentInfo?.includeEntity && entity ? entity : undefined
     }
   })

--- a/test/unit/logic/fetch-elements/fetch-items.spec.ts
+++ b/test/unit/logic/fetch-elements/fetch-items.spec.ts
@@ -70,7 +70,7 @@ describe('fetchEmotes', () => {
       {
         urn: 'urn1',
         amount: 1,
-        individualData: [{ id: 'id1', tokenId: 'tokenId1', transferredAt: 1, price: 10 }],
+        individualData: [{ id: 'urn1:tokenId1', tokenId: 'tokenId1', transferredAt: 1, price: 10 }],
         rarity: 'common',
         category: EmoteCategory.FUN,
         maxTransferredAt: 1,
@@ -134,8 +134,8 @@ describe('fetchEmotes', () => {
         urn: 'urn1',
         amount: 2,
         individualData: [
-          { id: 'id1', tokenId: 'tokenId1', transferredAt: 1, price: 10 },
-          { id: 'id2', tokenId: 'tokenId2', transferredAt: 2, price: 15 }
+          { id: 'urn1:tokenId1', tokenId: 'tokenId1', transferredAt: 1, price: 10 },
+          { id: 'urn1:tokenId2', tokenId: 'tokenId2', transferredAt: 2, price: 15 }
         ],
         rarity: 'common',
         category: EmoteCategory.FUN,
@@ -146,7 +146,7 @@ describe('fetchEmotes', () => {
       {
         urn: 'urn5',
         amount: 1,
-        individualData: [{ id: 'id5', tokenId: 'tokenId5', transferredAt: 5, price: 5 }],
+        individualData: [{ id: 'urn5:tokenId5', tokenId: 'tokenId5', transferredAt: 5, price: 5 }],
         rarity: 'rarity5',
         category: EmoteCategory.DANCE,
         maxTransferredAt: 5,
@@ -209,7 +209,7 @@ describe('fetchEmotes', () => {
       {
         urn: 'urn3',
         amount: 1,
-        individualData: [{ id: 'id3', tokenId: 'tokenId3', transferredAt: 3, price: 3 }],
+        individualData: [{ id: 'urn3:tokenId3', tokenId: 'tokenId3', transferredAt: 3, price: 3 }],
         rarity: 'unique',
         category: EmoteCategory.HORROR,
         maxTransferredAt: 3,
@@ -219,7 +219,7 @@ describe('fetchEmotes', () => {
       {
         urn: 'urn2',
         amount: 1,
-        individualData: [{ id: 'id2', tokenId: 'tokenId2', transferredAt: 2, price: 2 }],
+        individualData: [{ id: 'urn2:tokenId2', tokenId: 'tokenId2', transferredAt: 2, price: 2 }],
         rarity: 'rare',
         category: EmoteCategory.DANCE,
         maxTransferredAt: 2,
@@ -229,7 +229,7 @@ describe('fetchEmotes', () => {
       {
         urn: 'urn1',
         amount: 1,
-        individualData: [{ id: 'id1', tokenId: 'tokenId1', transferredAt: 1, price: 1 }],
+        individualData: [{ id: 'urn1:tokenId1', tokenId: 'tokenId1', transferredAt: 1, price: 1 }],
         rarity: 'common',
         category: EmoteCategory.FUN,
         maxTransferredAt: 1,
@@ -326,7 +326,7 @@ describe('fetchWearables', () => {
       {
         urn: 'urn1',
         amount: 1,
-        individualData: [{ id: 'id1', tokenId: 'tokenId1', transferredAt: 1, price: 1 }],
+        individualData: [{ id: 'urn1:tokenId1', tokenId: 'tokenId1', transferredAt: 1, price: 1 }],
         rarity: 'common',
         name: 'fun wearable',
         category: WearableCategory.EARRING,
@@ -336,7 +336,7 @@ describe('fetchWearables', () => {
       {
         urn: 'urn2',
         amount: 1,
-        individualData: [{ id: 'id2', tokenId: 'tokenId2', transferredAt: 2, price: 2 }],
+        individualData: [{ id: 'urn2:tokenId2', tokenId: 'tokenId2', transferredAt: 2, price: 2 }],
         rarity: 'common',
         name: 'dance wearable',
         category: WearableCategory.BODY_SHAPE,
@@ -403,7 +403,7 @@ describe('fetchWearables', () => {
       {
         urn: 'urn5',
         amount: 1,
-        individualData: [{ id: 'id5', tokenId: 'tokenId5', transferredAt: 5, price: 5 }],
+        individualData: [{ id: 'urn5:tokenId5', tokenId: 'tokenId5', transferredAt: 5, price: 5 }],
         rarity: 'unique',
         category: WearableCategory.EARRING,
         maxTransferredAt: 5,
@@ -414,8 +414,8 @@ describe('fetchWearables', () => {
         urn: 'urn1',
         amount: 2,
         individualData: [
-          { id: 'id1', tokenId: 'tokenId1', transferredAt: 1, price: 10 },
-          { id: 'id2', tokenId: 'tokenId2', transferredAt: 2, price: 15 }
+          { id: 'urn1:tokenId1', tokenId: 'tokenId1', transferredAt: 1, price: 10 },
+          { id: 'urn1:tokenId2', tokenId: 'tokenId2', transferredAt: 2, price: 15 }
         ],
         rarity: 'common',
         category: WearableCategory.EYEBROWS,
@@ -483,7 +483,7 @@ describe('fetchWearables', () => {
       {
         urn: 'urn3',
         amount: 1,
-        individualData: [{ id: 'id3', tokenId: 'tokenId3', transferredAt: 3, price: 3 }],
+        individualData: [{ id: 'urn3:tokenId3', tokenId: 'tokenId3', transferredAt: 3, price: 3 }],
         rarity: 'unique',
         category: 'eyes',
         maxTransferredAt: 3,
@@ -493,7 +493,7 @@ describe('fetchWearables', () => {
       {
         urn: 'urn2',
         amount: 1,
-        individualData: [{ id: 'id2', tokenId: 'tokenId2', transferredAt: 2, price: 2 }],
+        individualData: [{ id: 'urn2:tokenId2', tokenId: 'tokenId2', transferredAt: 2, price: 2 }],
         rarity: 'rare',
         category: 'eyes',
         maxTransferredAt: 2,
@@ -503,7 +503,7 @@ describe('fetchWearables', () => {
       {
         urn: 'urn1',
         amount: 1,
-        individualData: [{ id: 'id1', tokenId: 'tokenId1', transferredAt: 1, price: 1 }],
+        individualData: [{ id: 'urn1:tokenId1', tokenId: 'tokenId1', transferredAt: 1, price: 1 }],
         rarity: 'common',
         category: 'eyebrows',
         maxTransferredAt: 1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -383,10 +383,10 @@
     ts-poet "^6.4.1"
     ts-proto-descriptors "^1.15.0"
 
-"@dcl/urn-resolver@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@dcl/urn-resolver/-/urn-resolver-2.2.0.tgz#ea0759fd6f6584a83a07e7da7766966ae86245da"
-  integrity sha512-Ut399wl+YyGS9k9zzgENePK31YIEAK+triaqgUMPA44TO4bKOR6MxjjZe1RDYTkL5E8+6Q8tlaVXnz+xuVEK+g==
+"@dcl/urn-resolver@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@dcl/urn-resolver/-/urn-resolver-3.1.0.tgz#bc9ba521cde55e9e1b1bcbfaf428097e61fb72c4"
+  integrity sha512-g68ERxXPOYtBk1IMYtmWlCg8geX8AHCat/HLDOBNBcJIvNOEwGcnASYzENfdGa8mr8r7GlNmdI1O2ymn8V8aHw==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"


### PR DESCRIPTION
`Use this PR as reference for NFT Id implementation.`

This PR updates the endpoint specified in the [ADR-244](https://adr.decentraland.org/adr/ADR-244) to support returning extended NFTs URN when being called with the `erc721` query param.