### PR TITLE
fix: individual data representation of linked wearables

### DIFF
--- a/src/logic/fetch-elements/fetch-third-party-wearables.ts
+++ b/src/logic/fetch-elements/fetch-third-party-wearables.ts
@@ -64,14 +64,14 @@ function groupThirdPartyWearablesByURN(assets: (ThirdPartyAsset & { entity: Enti
     const metadata: Wearable = asset.entity.metadata
     if (wearablesByURN.has(asset.urn.decentraland)) {
       const wearableFromMap = wearablesByURN.get(asset.urn.decentraland)!
-      wearableFromMap.individualData.push({ id: asset.id })
+      wearableFromMap.individualData.push({ id: asset.urn.decentraland })
       wearableFromMap.amount = wearableFromMap.amount + 1
     } else {
       wearablesByURN.set(asset.urn.decentraland, {
         urn: asset.urn.decentraland,
         individualData: [
           {
-            id: asset.id
+            id: asset.urn.decentraland
           }
         ],
         amount: 1,

--- a/test/integration/explorer-handler.spec.ts
+++ b/test/integration/explorer-handler.spec.ts
@@ -336,7 +336,7 @@ function convertToMixedThirdPartyWearableResponse(
       amount: 1,
       individualData: [
         {
-          id: wearable.id
+          id: wearable.urn.decentraland
         }
       ],
       category: entity.metadata.data.category,

--- a/test/integration/third-party-wearables-handler/convert-to-model-third-party.ts
+++ b/test/integration/third-party-wearables-handler/convert-to-model-third-party.ts
@@ -21,7 +21,7 @@ export function convertToThirdPartyWearableResponse(
       amount: wearable.amount,
       individualData: [
         {
-          id: wearable.id
+          id: wearable.urn.decentraland
         }
       ],
       urn: wearable.urn.decentraland,

--- a/test/unit/logic/fetch-elements/fetch-third-party-wearables.spec.ts
+++ b/test/unit/logic/fetch-elements/fetch-third-party-wearables.spec.ts
@@ -72,11 +72,11 @@ describe('fetchAllThirdPartyWearables', () => {
         expect.objectContaining({
           urn: 'urn1',
           amount: 1,
-          individualData: [{ id: 'id1' }],
+          individualData: [{ id: 'urn1' }],
           name: 'nameForurn1',
           entity: expect.anything()
         }),
-        expect.objectContaining({ urn: 'urn2', amount: 1, individualData: [{ id: 'id2' }], name: 'nameForurn2' })
+        expect.objectContaining({ urn: 'urn2', amount: 1, individualData: [{ id: 'urn2' }], name: 'nameForurn2' })
       ] as ThirdPartyWearable[])
     })
   })
@@ -110,13 +110,13 @@ describe('fetchAllThirdPartyWearables', () => {
         {
           urn: 'urn1',
           amount: 2,
-          individualData: [{ id: 'id1' }, { id: 'id3' }],
+          individualData: [{ id: 'urn1' }, { id: 'urn1' }],
           name: entities[0].metadata.name
         },
         {
           urn: 'urn2',
           amount: 1,
-          individualData: [{ id: 'id2' }],
+          individualData: [{ id: 'urn2' }],
           name: entities[1].metadata.name
         }
       ] as ThirdPartyWearable[])


### PR DESCRIPTION
We need to handle these linked wearables a bit different from L1/L2 ones.

The main difference is that the content server (_active entities endpoint_) needs the whole URN to return the actual entity instead of the shortened URNs as the mentioned wearables do.

That's why the `individualData.id` and the `urn` properties are equal:
* IndividualData Id is used on client-side to grab the exact representation of the wearable (usually extended URN)
* URN is used to get the representation of the wearable from the content-server (_usually is shortened but for these kind of wearables we need it extended_)