### PR TITLE
fix: profile hasClaimedName value

### DIFF
--- a/src/adapters/profiles.ts
+++ b/src/adapters/profiles.ts
@@ -183,7 +183,7 @@ export async function createProfilesComponent(
 
             avatars.push({
               ...avatar,
-              hasClaimedName: ownedNames.findIndex((name) => name.name === avatar.name) !== -1,
+              hasClaimedName: avatar.hasClaimedName && ownedNames.findIndex((name) => name.name === avatar.name) !== -1,
               avatar: {
                 ...avatar.avatar,
                 emotes: validatedEmotes,


### PR DESCRIPTION
If a profile was deployed with unclaimed name and a given name, and later the user buys that name, unless there is a new deployment to equip it, lambdas should honor the fact that the currently deployed entity was unclaimed.