### PR TITLE
fix: Get all providers that are linked to an NFT

### DIFF
--- a/src/logic/fetch-elements/fetch-third-party-wearables.ts
+++ b/src/logic/fetch-elements/fetch-third-party-wearables.ts
@@ -258,14 +258,15 @@ async function _fetchThirdPartyWearables(
     const providersThatReturnedNfts = new Set<string>()
     for (const nft of nfts) {
       const [network, contractAddress] = nft.split(':')
-      // TODO Performance could be improved here by having indexed the providers by their network and contract addresses
-      const provider = linkedWearableProviders.find((provider) =>
+      const providers = linkedWearableProviders.filter((provider) =>
         (provider.metadata.thirdParty.contracts || []).find(
           (contract) => contract.network === network && contract.address === contractAddress
         )
       )
-      if (provider) {
-        providersThatReturnedNfts.add(`${provider.id}`)
+      if (providers.length > 0) {
+        for (const provider of providers) {
+          providersThatReturnedNfts.add(`${provider.id}`)
+        }
       }
     }
 


### PR DESCRIPTION
This PR fixes an issue where we were looking for one provider that contained the address and the network of an NFT owned by a user but it didn't take into consideration all of the providers.