### PR TITLE
feat: Remove repeated linked wearables

### DIFF
--- a/src/logic/fetch-elements/fetch-third-party-wearables.ts
+++ b/src/logic/fetch-elements/fetch-third-party-wearables.ts
@@ -300,7 +300,7 @@ async function _fetchThirdPartyWearables(
   }
 
   const providersV1 = thirdParties.filter((provider) => provider.resolver !== null || provider.resolver !== 'Disabled')
-  const providersV2 = thirdParties.filter((provider) => (provider.metadata.thirdParty.contracts?.length ?? 0) < 0)
+  const providersV2 = thirdParties.filter((provider) => (provider.metadata.thirdParty.contracts?.length ?? 0) > 0)
 
   const [thirdPartyV1, thirdPartyV2] = await Promise.all([
     fetchThirdPartyV1(providersV1),

--- a/src/logic/fetch-elements/fetch-third-party-wearables.ts
+++ b/src/logic/fetch-elements/fetch-third-party-wearables.ts
@@ -316,7 +316,17 @@ async function _fetchThirdPartyWearables(
     fetchThirdPartyV2(providersV2)
   ])
 
-  return [...thirdPartyV1, ...thirdPartyV2]
+  const allThirdPartyWearables = [...thirdPartyV1, ...thirdPartyV2]
+  const thirdPartyWearablesByUrn = allThirdPartyWearables.reduce(
+    (acc, tpw) => {
+      // If there are repeated wearables, we should merge them
+      acc[tpw.urn] = tpw
+      return acc
+    },
+    {} as Record<string, ThirdPartyWearable>
+  )
+
+  return Object.values(thirdPartyWearablesByUrn)
 }
 
 export async function fetchThirdPartyWearablesFromThirdPartyName(

--- a/src/logic/fetch-elements/fetch-third-party-wearables.ts
+++ b/src/logic/fetch-elements/fetch-third-party-wearables.ts
@@ -299,17 +299,8 @@ async function _fetchThirdPartyWearables(
     return groupLinkedWearablesByURN(assignedLinkedWearables)
   }
 
-  const [providersV1, providersV2] = thirdParties.reduce(
-    (acc, provider) => {
-      if ((provider.metadata.thirdParty.contracts?.length || 0) <= 0) {
-        acc[0].push(provider)
-      } else {
-        acc[1].push(provider)
-      }
-      return acc
-    },
-    [[], []] as ThirdPartyProvider[][]
-  )
+  const providersV1 = thirdParties.filter((provider) => provider.resolver !== null || provider.resolver !== 'Disabled')
+  const providersV2 = thirdParties.filter((provider) => (provider.metadata.thirdParty.contracts?.length ?? 0) < 0)
 
   const [thirdPartyV1, thirdPartyV2] = await Promise.all([
     fetchThirdPartyV1(providersV1),


### PR DESCRIPTION
This PR takes the Linked Wearables from the resolver APIs and the ones from the item's mappings and removes duplicates.