### PR TITLE
feat: use ID instead of String in The Graph query

### DIFF
--- a/src/logic/fetch-elements/fetch-items.ts
+++ b/src/logic/fetch-elements/fetch-items.ts
@@ -43,7 +43,7 @@ function groupItemsByURN<
 type ItemCategory = 'wearable' | 'emote'
 
 function createQueryForCategory(category: ItemCategory) {
-  return `query fetchItemsByOwner($owner: String, $idFrom: String) {
+  return `query fetchItemsByOwner($owner: String, $idFrom: ID) {
     nfts(
       where: { id_gt: $idFrom, owner: $owner, category: "${category}"},
       orderBy: id,

--- a/src/logic/fetch-elements/fetch-lands.ts
+++ b/src/logic/fetch-elements/fetch-lands.ts
@@ -2,7 +2,7 @@ import { AppComponents, LAND } from '../../types'
 import { fetchAllNFTs, THE_GRAPH_PAGE_SIZE } from './fetch-elements'
 
 const QUERY_LANDS: string = `
-  query fetchLANDsByOwner($owner: String, $idFrom: String) {
+  query fetchLANDsByOwner($owner: String, $idFrom: ID) {
     nfts(
       where: { owner: $owner, category_in: [parcel, estate], id_gt: $idFrom },
       orderBy: transferredAt,

--- a/src/logic/fetch-elements/fetch-names.ts
+++ b/src/logic/fetch-elements/fetch-names.ts
@@ -2,7 +2,7 @@ import { AppComponents, Name } from '../../types'
 import { fetchAllNFTs, THE_GRAPH_PAGE_SIZE } from './fetch-elements'
 
 const QUERY_NAMES_PAGINATED: string = `
-  query fetchNamesByOwner($owner: String, $idFrom: String) {
+  query fetchNamesByOwner($owner: String, $idFrom: ID) {
     nfts(
       where: {owner: $owner, category: "ens", id_gt: $idFrom }
       orderBy: id,

--- a/test/unit/logic/fetch-elements/fetch-items.spec.ts
+++ b/test/unit/logic/fetch-elements/fetch-items.spec.ts
@@ -15,7 +15,7 @@ describe('fetchEmotes', () => {
     const owner = 'anOwner'
     await fetchAllEmotes({ theGraph }, owner)
     expect(theGraph.maticCollectionsSubgraph.query).toBeCalled()
-    const expectedQuery = `query fetchItemsByOwner($owner: String, $idFrom: String) {
+    const expectedQuery = `query fetchItemsByOwner($owner: String, $idFrom: ID) {
     nfts(
       where: { id_gt: $idFrom, owner: $owner, category: "emote"},
       orderBy: id,
@@ -249,7 +249,7 @@ describe('fetchWearables', () => {
     await fetchAllWearables({ theGraph }, owner)
     expect(theGraph.ethereumCollectionsSubgraph.query).toBeCalled()
     expect(theGraph.maticCollectionsSubgraph.query).toBeCalled()
-    const expectedQuery = `query fetchItemsByOwner($owner: String, $idFrom: String) {
+    const expectedQuery = `query fetchItemsByOwner($owner: String, $idFrom: ID) {
     nfts(
       where: { id_gt: $idFrom, owner: $owner, category: "wearable"},
       orderBy: id,


### PR DESCRIPTION
This query won't be supported by The Graph in a near future, we need to adapt it so it follows graphql spec

![image](https://github.com/user-attachments/assets/65ebeb44-bf98-428d-8b7d-c66db3528eb5)
