### PR TITLE
feat: change items queries to use itemType filter instead of category

### DIFF
--- a/src/logic/fetch-elements/fetch-items.ts
+++ b/src/logic/fetch-elements/fetch-items.ts
@@ -43,9 +43,11 @@ function groupItemsByURN<
 type ItemCategory = 'wearable' | 'emote'
 
 function createQueryForCategory(category: ItemCategory) {
+  const itemTypeFilter =
+    category === 'wearable' ? `itemType_in: [wearable_v1, wearable_v2, smart_wearable_v1]` : `itemType: emote_v1`
   return `query fetchItemsByOwner($owner: String, $idFrom: ID) {
     nfts(
-      where: { id_gt: $idFrom, owner: $owner, category: "${category}"},
+      where: { id_gt: $idFrom, owner: $owner, ${itemTypeFilter}},
       orderBy: id,
       orderDirection: asc,
       first: ${THE_GRAPH_PAGE_SIZE}

--- a/src/logic/fetch-elements/fetch-names.ts
+++ b/src/logic/fetch-elements/fetch-names.ts
@@ -4,7 +4,7 @@ import { fetchAllNFTs, THE_GRAPH_PAGE_SIZE } from './fetch-elements'
 const QUERY_NAMES_PAGINATED: string = `
   query fetchNamesByOwner($owner: String, $idFrom: ID) {
     nfts(
-      where: {owner: $owner, category: "ens", id_gt: $idFrom }
+      where: {owner: $owner, category: ens, id_gt: $idFrom }
       orderBy: id,
       orderDirection: asc,
       first: ${THE_GRAPH_PAGE_SIZE}

--- a/test/integration/outfits-controller.spec.ts
+++ b/test/integration/outfits-controller.spec.ts
@@ -113,7 +113,7 @@ testWithComponents(() => {
       })
     })
     theGraph.maticCollectionsSubgraph.query = jest.fn().mockImplementation((query: string) => {
-      if (query.includes(`category: "wearable"`)) {
+      if (query.includes(`itemType_in: [wearable_v1, wearable_v2, smart_wearable_v1]`)) {
         return Promise.resolve({
           nfts: [
             {
@@ -169,7 +169,7 @@ testWithComponents(() => {
             }
           ]
         })
-      } else if (query.includes(`category: "emote"`)) {
+      } else if (query.includes(`itemType: emote_v1`)) {
         return Promise.resolve({ nfts: [] })
       }
     })
@@ -307,7 +307,7 @@ testWithComponents(() => {
       })
     })
     theGraph.maticCollectionsSubgraph.query = jest.fn().mockImplementation((query: string) => {
-      if (query.includes(`category: "wearable"`)) {
+      if (query.includes(`itemType_in: [wearable_v1, wearable_v2, smart_wearable_v1]`)) {
         return Promise.resolve({
           nfts: [
             {
@@ -363,7 +363,7 @@ testWithComponents(() => {
             }
           ]
         })
-      } else if (query.includes(`category: "emote"`)) {
+      } else if (query.includes(`itemType: emote_v1`)) {
         return Promise.resolve({ nfts: [] })
       }
     })
@@ -533,7 +533,7 @@ testWithComponents(() => {
       })
     })
     theGraph.maticCollectionsSubgraph.query = jest.fn().mockImplementation((query: string) => {
-      if (query.includes(`category: "wearable"`)) {
+      if (query.includes(`itemType_in: [wearable_v1, wearable_v2, smart_wearable_v1]`)) {
         return Promise.resolve({
           nfts: [
             {
@@ -589,7 +589,7 @@ testWithComponents(() => {
             }
           ]
         })
-      } else if (query.includes(`category: "emote"`)) {
+      } else if (query.includes(`itemType: emote_v1`)) {
         return Promise.resolve({ nfts: [] })
       }
     })
@@ -714,7 +714,7 @@ testWithComponents(() => {
       })
     })
     theGraph.maticCollectionsSubgraph.query = jest.fn().mockImplementation((query: string) => {
-      if (query.includes(`category: "wearable"`)) {
+      if (query.includes(`itemType_in: [wearable_v1, wearable_v2, smart_wearable_v1]`)) {
         return Promise.resolve({
           nfts: [
             {
@@ -770,7 +770,7 @@ testWithComponents(() => {
             }
           ]
         })
-      } else if (query.includes(`category: "emote"`)) {
+      } else if (query.includes(`itemType: emote_v1`)) {
         return Promise.resolve({ nfts: [] })
       }
     })
@@ -984,7 +984,7 @@ testWithComponents(() => {
       })
     })
     theGraph.maticCollectionsSubgraph.query = jest.fn().mockImplementation((query: string) => {
-      if (query.includes(`category: "wearable"`)) {
+      if (query.includes(`itemType_in: [wearable_v1, wearable_v2, smart_wearable_v1]`)) {
         return Promise.resolve({
           nfts: [
             {
@@ -1006,7 +1006,7 @@ testWithComponents(() => {
             }
           ]
         })
-      } else if (query.includes(`category: "emote"`)) {
+      } else if (query.includes(`itemType: emote_v1`)) {
         return Promise.resolve({ nfts: [] })
       }
     })
@@ -1218,7 +1218,7 @@ testWithComponents(() => {
       })
     })
     theGraph.maticCollectionsSubgraph.query = jest.fn().mockImplementation((query: string) => {
-      if (query.includes(`category: "wearable"`)) {
+      if (query.includes(`itemType_in: [wearable_v1, wearable_v2, smart_wearable_v1]`)) {
         return Promise.resolve({
           nfts: [
             {
@@ -1240,7 +1240,7 @@ testWithComponents(() => {
             }
           ]
         })
-      } else if (query.includes(`category: "emote"`)) {
+      } else if (query.includes(`itemType: emote_v1`)) {
         return Promise.resolve({ nfts: [] })
       }
     })
@@ -1460,7 +1460,7 @@ testWithComponents(() => {
       })
     })
     theGraph.maticCollectionsSubgraph.query = jest.fn().mockImplementation((query: string) => {
-      if (query.includes(`category: "wearable"`)) {
+      if (query.includes(`itemType_in: [wearable_v1, wearable_v2, smart_wearable_v1]`)) {
         return Promise.resolve({
           nfts: [
             {
@@ -1482,7 +1482,7 @@ testWithComponents(() => {
             }
           ]
         })
-      } else if (query.includes(`category: "emote"`)) {
+      } else if (query.includes(`itemType: emote_v1`)) {
         return Promise.resolve({ nfts: [] })
       }
     })

--- a/test/integration/profile-adapter.spec.ts
+++ b/test/integration/profile-adapter.spec.ts
@@ -74,7 +74,7 @@ test('integration tests for profile adapter', function ({ components, stubCompon
     })
 
     theGraph.maticCollectionsSubgraph.query = jest.fn().mockImplementation(async (query: string) => {
-      if (query.includes(`category: "wearable"`)) {
+      if (query.includes(`itemType_in: [wearable_v1, wearable_v2, smart_wearable_v1]`)) {
         return {
           nfts: [
             {
@@ -113,7 +113,7 @@ test('integration tests for profile adapter', function ({ components, stubCompon
             }
           ]
         }
-      } else if (query.includes(`category: "emote"`)) {
+      } else if (query.includes(`itemType: emote_v1`)) {
         return { nfts: [] }
       }
     })
@@ -285,7 +285,7 @@ testWithComponents(() => {
       })
 
       theGraph.maticCollectionsSubgraph.query = jest.fn().mockImplementation(async (query: string) => {
-        if (query.includes(`category: "wearable"`)) {
+        if (query.includes(`itemType_in: [wearable_v1, wearable_v2, smart_wearable_v1]`)) {
           return {
             nfts: [
               {
@@ -324,7 +324,7 @@ testWithComponents(() => {
               }
             ]
           }
-        } else if (query.includes(`category: "emote"`)) {
+        } else if (query.includes(`itemType: emote_v1`)) {
           return { nfts: [] }
         }
       })
@@ -489,7 +489,7 @@ testWithComponents(() => {
       })
 
       theGraph.maticCollectionsSubgraph.query = jest.fn().mockImplementation(async (query: string) => {
-        if (query.includes(`category: "wearable"`)) {
+        if (query.includes(`itemType_in: [wearable_v1, wearable_v2, smart_wearable_v1]`)) {
           return {
             nfts: [
               {
@@ -545,7 +545,7 @@ testWithComponents(() => {
               }
             ]
           }
-        } else if (query.includes(`category: "emote"`)) {
+        } else if (query.includes(`itemType: emote_v1`)) {
           return { nfts: [] }
         }
       })

--- a/test/unit/logic/fetch-elements/fetch-items.spec.ts
+++ b/test/unit/logic/fetch-elements/fetch-items.spec.ts
@@ -17,7 +17,7 @@ describe('fetchEmotes', () => {
     expect(theGraph.maticCollectionsSubgraph.query).toBeCalled()
     const expectedQuery = `query fetchItemsByOwner($owner: String, $idFrom: ID) {
     nfts(
-      where: { id_gt: $idFrom, owner: $owner, category: "emote"},
+      where: { id_gt: $idFrom, owner: $owner, itemType: emote_v1},
       orderBy: id,
       orderDirection: asc,
       first: 1000
@@ -251,7 +251,7 @@ describe('fetchWearables', () => {
     expect(theGraph.maticCollectionsSubgraph.query).toBeCalled()
     const expectedQuery = `query fetchItemsByOwner($owner: String, $idFrom: ID) {
     nfts(
-      where: { id_gt: $idFrom, owner: $owner, category: "wearable"},
+      where: { id_gt: $idFrom, owner: $owner, itemType_in: [wearable_v1, wearable_v2, smart_wearable_v1]},
       orderBy: id,
       orderDirection: asc,
       first: 1000


### PR DESCRIPTION
The motivation of this PR is to adapt some queries to work both on Subsquid and The Graph/Satsuma. The problem with the current ones is that they use the `category` filter as a string, which is a `enum` in [Subsquid](https://github.com/decentraland/marketplace-squid/blob/main/schema.graphql#L53) (it was defined that way because the marketplace subgraph had it that way). 
Changing the `category` filter to the `itemType` one ensures that the query will have the same output and will work both on Subsquid and The Graph/Satsuma.