### PR TITLE
feat: adapt ownership queries to use the address instead of ID

### DIFF
--- a/src/logic/fetch-elements/fetch-items.ts
+++ b/src/logic/fetch-elements/fetch-items.ts
@@ -47,7 +47,7 @@ function createQueryForCategory(category: ItemCategory) {
     category === 'wearable' ? `itemType_in: [wearable_v1, wearable_v2, smart_wearable_v1]` : `itemType: emote_v1`
   return `query fetchItemsByOwner($owner: String, $idFrom: ID) {
     nfts(
-      where: { id_gt: $idFrom, owner: $owner, ${itemTypeFilter}},
+      where: { id_gt: $idFrom, owner_: {address: $owner}, ${itemTypeFilter}},
       orderBy: id,
       orderDirection: asc,
       first: ${THE_GRAPH_PAGE_SIZE}

--- a/src/logic/fetch-elements/fetch-lands.ts
+++ b/src/logic/fetch-elements/fetch-lands.ts
@@ -4,7 +4,7 @@ import { fetchAllNFTs, THE_GRAPH_PAGE_SIZE } from './fetch-elements'
 const QUERY_LANDS: string = `
   query fetchLANDsByOwner($owner: String, $idFrom: ID) {
     nfts(
-      where: { owner: $owner, category_in: [parcel, estate], id_gt: $idFrom },
+      where: { owner_: {address: $owner}, category_in: [parcel, estate], id_gt: $idFrom },
       orderBy: transferredAt,
       orderDirection: desc,
       first: ${THE_GRAPH_PAGE_SIZE}

--- a/src/logic/fetch-elements/fetch-names.ts
+++ b/src/logic/fetch-elements/fetch-names.ts
@@ -4,7 +4,7 @@ import { fetchAllNFTs, THE_GRAPH_PAGE_SIZE } from './fetch-elements'
 const QUERY_NAMES_PAGINATED: string = `
   query fetchNamesByOwner($owner: String, $idFrom: ID) {
     nfts(
-      where: {owner: $owner, category: ens, id_gt: $idFrom }
+      where: {owner_: {address: $owner}, category: ens, id_gt: $idFrom }
       orderBy: id,
       orderDirection: asc,
       first: ${THE_GRAPH_PAGE_SIZE}

--- a/test/unit/logic/fetch-elements/fetch-items.spec.ts
+++ b/test/unit/logic/fetch-elements/fetch-items.spec.ts
@@ -17,7 +17,7 @@ describe('fetchEmotes', () => {
     expect(theGraph.maticCollectionsSubgraph.query).toBeCalled()
     const expectedQuery = `query fetchItemsByOwner($owner: String, $idFrom: ID) {
     nfts(
-      where: { id_gt: $idFrom, owner: $owner, itemType: emote_v1},
+      where: { id_gt: $idFrom, owner_: {address: $owner}, itemType: emote_v1},
       orderBy: id,
       orderDirection: asc,
       first: 1000
@@ -251,7 +251,7 @@ describe('fetchWearables', () => {
     expect(theGraph.maticCollectionsSubgraph.query).toBeCalled()
     const expectedQuery = `query fetchItemsByOwner($owner: String, $idFrom: ID) {
     nfts(
-      where: { id_gt: $idFrom, owner: $owner, itemType_in: [wearable_v1, wearable_v2, smart_wearable_v1]},
+      where: { id_gt: $idFrom, owner_: {address: $owner}, itemType_in: [wearable_v1, wearable_v2, smart_wearable_v1]},
       orderBy: id,
       orderDirection: asc,
       first: 1000


### PR DESCRIPTION

## Context
Since Subsquid is running in both Ethereum and Polygon at the same time and writting to the same db, to avoid concurrency issues, it stores the accounts with the chain appened to the end of the ID. E:g: `0x747c6f502272129bf1ba872a1903045b837ee86c-POLYGON`. 

## What this PR does
In order to make these queries compatible with both Subsquid and The Graph, we can query by address, which is going to be just the wallet address with out suffix. 