### PR TITLE
fix: use internal content url for server fetches

### DIFF
--- a/src/adapters/content-server-url.ts
+++ b/src/adapters/content-server-url.ts
@@ -1,7 +1,11 @@
 import { AppComponents } from '../types'
 
-export async function createContentServerUrl(components: Pick<AppComponents, 'config'>): Promise<string> {
-  let configAddress: string = (await components.config.getString('CONTENT_URL')) ?? 'http://content-server:6969'
+export type ContentServerUrls = {
+  publicUrl: string
+  internalUrl: string
+}
+
+function normalizeContentServerUrl(configAddress: string): string {
   configAddress = configAddress.toLowerCase()
   if (!configAddress.startsWith('http')) {
     configAddress = 'http://' + configAddress
@@ -10,4 +14,31 @@ export async function createContentServerUrl(components: Pick<AppComponents, 'co
     configAddress = configAddress.slice(0, -1)
   }
   return configAddress
+}
+
+/**
+ * Creates the public and internal content server URLs.
+ *
+ * Public URLs are used for response payloads and asset links clients must access.
+ * Internal URLs are used for server-side fetches to avoid routing through the public internet.
+ */
+export async function createContentServerUrls(components: Pick<AppComponents, 'config'>): Promise<ContentServerUrls> {
+  const publicUrl = normalizeContentServerUrl(
+    (await components.config.getString('CONTENT_URL')) ?? 'http://content-server:6969'
+  )
+  const internalUrl = normalizeContentServerUrl(
+    (await components.config.getString('INTERNAL_CONTENT_URL')) ?? publicUrl
+  )
+
+  return {
+    publicUrl,
+    internalUrl
+  }
+}
+
+/**
+ * Creates the public content server URL.
+ */
+export async function createContentServerUrl(components: Pick<AppComponents, 'config'>): Promise<string> {
+  return (await createContentServerUrls(components)).publicUrl
 }

--- a/src/adapters/entities-fetcher.ts
+++ b/src/adapters/entities-fetcher.ts
@@ -38,9 +38,12 @@ export async function createEntitiesFetcherComponent({
   config,
   content,
   logs,
-  contentServerUrl,
+  internalContentServerUrl,
   fetch
-}: Pick<AppComponents, 'logs' | 'config' | 'content' | 'contentServerUrl' | 'fetch'>): Promise<EntitiesFetcher> {
+}: Pick<
+  AppComponents,
+  'logs' | 'config' | 'content' | 'internalContentServerUrl' | 'fetch'
+>): Promise<EntitiesFetcher> {
   const itemsSize = (await config.getNumber('ITEMS_CACHE_MAX_SIZE')) ?? 10000
   const itemsAge = (await config.getNumber('ITEMS_CACHE_MAX_AGE')) ?? 600000 // 10 minutes by default
 
@@ -59,7 +62,7 @@ export async function createEntitiesFetcherComponent({
     collectionId: string,
     pageNum: number = 1
   ): Promise<LinkedWearableAssetEntities | undefined> {
-    const url = `${contentServerUrl}/entities/active/collections/${collectionId}?pageSize=${MAX_COLLECTION_PAGE_SIZE}&pageNum=${pageNum}`
+    const url = `${internalContentServerUrl}/entities/active/collections/${collectionId}?pageSize=${MAX_COLLECTION_PAGE_SIZE}&pageNum=${pageNum}`
     const response = await fetch.fetch(url)
     if (!response.ok) {
       return response.status === 404

--- a/src/adapters/third-party-collections-cache-warmer.ts
+++ b/src/adapters/third-party-collections-cache-warmer.ts
@@ -26,10 +26,10 @@ export type CacheWarmerStatus = {
 export async function createThirdPartyCollectionsCacheWarmer(
   components: Pick<
     AppComponents,
-    'config' | 'logs' | 'thirdPartyProvidersStorage' | 'entitiesFetcher' | 'fetch' | 'contentServerUrl'
+    'config' | 'logs' | 'thirdPartyProvidersStorage' | 'entitiesFetcher' | 'fetch' | 'internalContentServerUrl'
   >
 ): Promise<ThirdPartyCollectionsCacheWarmer> {
-  const { config, logs, thirdPartyProvidersStorage, entitiesFetcher, fetch, contentServerUrl } = components
+  const { config, logs, thirdPartyProvidersStorage, entitiesFetcher, fetch, internalContentServerUrl } = components
   const logger = logs.getLogger('third-party-collections-cache-warmer')
 
   const enabled = (await config.getString('DISABLE_CACHE_WARMER'))?.toLowerCase() !== 'true'
@@ -55,7 +55,7 @@ export async function createThirdPartyCollectionsCacheWarmer(
    */
   async function isContentServerReady(): Promise<boolean> {
     try {
-      const statusUrl = `${contentServerUrl}/status`
+      const statusUrl = `${internalContentServerUrl}/status`
       logger.debug('[isContentServerReady] Checking content server health', { statusUrl })
 
       const response = await fetch.fetch(statusUrl)

--- a/src/components.ts
+++ b/src/components.ts
@@ -10,7 +10,7 @@ import { createMetricsComponent } from '@well-known-components/metrics'
 import { createContentClient } from 'dcl-catalyst-client'
 import { HTTPProvider } from 'eth-connect'
 import { createCatalystsFetcher } from './adapters/catalysts-fetcher'
-import { createContentServerUrl } from './adapters/content-server-url'
+import { createContentServerUrls } from './adapters/content-server-url'
 import {
   createEmoteDefinitionsFetcherComponent,
   createWearableDefinitionsFetcherComponent
@@ -64,8 +64,10 @@ export async function initComponents(
   const metrics = await createMetricsComponent(metricDeclarations, { config })
   await instrumentHttpServerWithPromClientRegistry({ server, metrics, config, registry: metrics.registry! })
 
-  const contentServerUrl = await createContentServerUrl({ config })
-  const content = createContentClient({ url: contentServerUrl, fetcher: fetch })
+  const { publicUrl: contentServerUrl, internalUrl: internalContentServerUrl } = await createContentServerUrls({
+    config
+  })
+  const content = createContentClient({ url: internalContentServerUrl, fetcher: fetch })
 
   const theGraph = theGraphComponent
     ? theGraphComponent
@@ -80,8 +82,14 @@ export async function initComponents(
     contentServerUrl
   })
 
-  // TODO: use content client for collection items fetching. prevent injecting contentServerUrl and fetch components.
-  const entitiesFetcher = await createEntitiesFetcherComponent({ config, logs, content, contentServerUrl, fetch })
+  // TODO: use content client for collection items fetching. prevent injecting internalContentServerUrl and fetch components.
+  const entitiesFetcher = await createEntitiesFetcherComponent({
+    config,
+    logs,
+    content,
+    internalContentServerUrl,
+    fetch
+  })
 
   // Create marketplace API fetcher for primary data source
   const marketplaceApiFetcher = await createMarketplaceApiFetcher({ config, fetch, logs })
@@ -202,7 +210,7 @@ export async function initComponents(
     thirdPartyProvidersStorage,
     entitiesFetcher,
     fetch,
-    contentServerUrl
+    internalContentServerUrl
   })
 
   return {
@@ -229,6 +237,7 @@ export async function initComponents(
     thirdPartyProvidersGraphFetcher,
     thirdPartyProvidersStorage,
     contentServerUrl,
+    internalContentServerUrl,
     resourcesStatusCheck,
     status,
     l1Provider,

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export type BaseComponents = {
   metrics: IMetricsComponent<keyof typeof metricDeclarations>
   content: Pick<ContentClient, 'fetchEntitiesByPointers'>
   contentServerUrl: string
+  internalContentServerUrl: string
   theGraph: TheGraphComponent
   ownershipCaches: OwnershipCachesComponent
   baseWearablesFetcher: ElementsFetcher<BaseWearable>

--- a/test/components.ts
+++ b/test/components.ts
@@ -132,8 +132,9 @@ async function initComponents(
   )
 
   const contentServerUrl = 'baseUrl'
+  const internalContentServerUrl = 'baseUrl'
 
-  const entitiesFetcher = await createEntitiesFetcherComponent({ config, logs, content, contentServerUrl, fetch })
+  const entitiesFetcher = await createEntitiesFetcherComponent({ config, logs, content, internalContentServerUrl, fetch })
 
   const wearableDefinitionsFetcher = await createWearableDefinitionsFetcherComponent({
     config,
@@ -183,6 +184,7 @@ async function initComponents(
     theGraph: theGraphMock,
     content,
     contentServerUrl,
+    internalContentServerUrl,
     wearablesFetcher,
     entitiesFetcher,
     emotesFetcher,

--- a/test/unit/adapters/content-server-url.spec.ts
+++ b/test/unit/adapters/content-server-url.spec.ts
@@ -1,0 +1,41 @@
+import { createConfigComponent } from '@well-known-components/env-config-provider'
+import { createContentServerUrls } from '../../../src/adapters/content-server-url'
+
+describe('when creating content server urls', () => {
+  describe('and an internal content url is configured', () => {
+    let urls: Awaited<ReturnType<typeof createContentServerUrls>>
+
+    beforeEach(async () => {
+      const config = createConfigComponent({
+        CONTENT_URL: 'https://peer.decentraland.org/content/',
+        INTERNAL_CONTENT_URL: 'content-server:6969/'
+      })
+
+      urls = await createContentServerUrls({ config })
+    })
+
+    it('should use the public content url for returned urls', () => {
+      expect(urls.publicUrl).toBe('https://peer.decentraland.org/content')
+    })
+
+    it('should use the internal content url for fetch urls', () => {
+      expect(urls.internalUrl).toBe('http://content-server:6969')
+    })
+  })
+
+  describe('and an internal content url is not configured', () => {
+    let urls: Awaited<ReturnType<typeof createContentServerUrls>>
+
+    beforeEach(async () => {
+      const config = createConfigComponent({
+        CONTENT_URL: 'https://peer.decentraland.org/content/'
+      })
+
+      urls = await createContentServerUrls({ config })
+    })
+
+    it('should fall back to the public content url for fetch urls', () => {
+      expect(urls.internalUrl).toBe('https://peer.decentraland.org/content')
+    })
+  })
+})

--- a/test/unit/adapters/third-party-collections-cache-warmer.spec.ts
+++ b/test/unit/adapters/third-party-collections-cache-warmer.spec.ts
@@ -17,7 +17,7 @@ import {
 describe('when creating the third-party collections cache warmer component', () => {
   let components: Pick<
     AppComponents,
-    'config' | 'logs' | 'thirdPartyProvidersStorage' | 'entitiesFetcher' | 'fetch' | 'contentServerUrl'
+    'config' | 'logs' | 'thirdPartyProvidersStorage' | 'entitiesFetcher' | 'fetch' | 'internalContentServerUrl'
   >
   let mockConfig: IConfigComponent
   let mockLogs: ILoggerComponent
@@ -25,7 +25,7 @@ describe('when creating the third-party collections cache warmer component', () 
   let mockThirdPartyProvidersStorage: ThirdPartyProvidersStorage
   let mockEntitiesFetcher: EntitiesFetcher
   let mockFetch: IFetchComponent
-  let contentServerUrl: string
+  let internalContentServerUrl: string
 
   beforeEach(() => {
     mockConfig = createConfigMock()
@@ -34,7 +34,7 @@ describe('when creating the third-party collections cache warmer component', () 
     mockThirdPartyProvidersStorage = createThirdPartyProvidersStorageMock()
     mockEntitiesFetcher = createEntitiesFetcherMock()
     mockFetch = createFetchMock()
-    contentServerUrl = 'http://test-content-server.com'
+    internalContentServerUrl = 'http://test-internal-content-server.com'
 
     components = {
       config: mockConfig,
@@ -42,7 +42,7 @@ describe('when creating the third-party collections cache warmer component', () 
       thirdPartyProvidersStorage: mockThirdPartyProvidersStorage,
       entitiesFetcher: mockEntitiesFetcher,
       fetch: mockFetch,
-      contentServerUrl
+      internalContentServerUrl
     }
   })
 
@@ -136,7 +136,7 @@ describe('when the cache warmer component is disabled', () => {
   let warmer: ThirdPartyCollectionsCacheWarmer
   let components: Pick<
     AppComponents,
-    'config' | 'logs' | 'thirdPartyProvidersStorage' | 'entitiesFetcher' | 'fetch' | 'contentServerUrl'
+    'config' | 'logs' | 'thirdPartyProvidersStorage' | 'entitiesFetcher' | 'fetch' | 'internalContentServerUrl'
   >
   let mockConfig: IConfigComponent
   let mockLogs: ILoggerComponent
@@ -159,7 +159,7 @@ describe('when the cache warmer component is disabled', () => {
       thirdPartyProvidersStorage: mockThirdPartyProvidersStorage,
       entitiesFetcher: mockEntitiesFetcher,
       fetch: mockFetch,
-      contentServerUrl: 'http://test-content-server.com'
+      internalContentServerUrl: 'http://test-internal-content-server.com'
     }
     ;(mockConfig.getString as jest.Mock).mockResolvedValueOnce('true')
     ;(mockConfig.getNumber as jest.Mock).mockResolvedValue(undefined)
@@ -195,7 +195,7 @@ describe('when the cache warmer component is enabled', () => {
   let warmer: ThirdPartyCollectionsCacheWarmer
   let components: Pick<
     AppComponents,
-    'config' | 'logs' | 'thirdPartyProvidersStorage' | 'entitiesFetcher' | 'fetch' | 'contentServerUrl'
+    'config' | 'logs' | 'thirdPartyProvidersStorage' | 'entitiesFetcher' | 'fetch' | 'internalContentServerUrl'
   >
   let mockConfig: IConfigComponent
   let mockLogs: ILoggerComponent
@@ -203,7 +203,7 @@ describe('when the cache warmer component is enabled', () => {
   let mockThirdPartyProvidersStorage: ThirdPartyProvidersStorage
   let mockEntitiesFetcher: EntitiesFetcher
   let mockFetch: IFetchComponent
-  let contentServerUrl: string
+  let internalContentServerUrl: string
 
   beforeEach(async () => {
     mockConfig = createConfigMock()
@@ -212,7 +212,7 @@ describe('when the cache warmer component is enabled', () => {
     mockThirdPartyProvidersStorage = createThirdPartyProvidersStorageMock()
     mockEntitiesFetcher = createEntitiesFetcherMock()
     mockFetch = createFetchMock()
-    contentServerUrl = 'http://test-content-server.com'
+    internalContentServerUrl = 'http://test-internal-content-server.com'
 
     components = {
       config: mockConfig,
@@ -220,7 +220,7 @@ describe('when the cache warmer component is enabled', () => {
       thirdPartyProvidersStorage: mockThirdPartyProvidersStorage,
       entitiesFetcher: mockEntitiesFetcher,
       fetch: mockFetch,
-      contentServerUrl
+      internalContentServerUrl
     }
     ;(mockConfig.getString as jest.Mock).mockResolvedValueOnce('false')
     ;(mockConfig.getNumber as jest.Mock).mockResolvedValue(undefined)


### PR DESCRIPTION
## Why

Server-side content fetches were using CONTENT_URL, which is the public Content Server URL. In deployments with an internal content service address, that can route Lambdas traffic out through the public internet even though the service is reachable internally.

We still need CONTENT_URL for URLs returned to clients, such as /about.content.publicUrl and generated /contents/{hash} asset URLs, because clients must receive the public address.

## How

This separates the content server configuration into public and internal URLs:

- CONTENT_URL remains the public URL used in response payloads and crafted asset URLs.
- INTERNAL_CONTENT_URL is used for server-side content fetches when configured.
- If INTERNAL_CONTENT_URL is not configured, fetches fall back to CONTENT_URL to preserve current behavior.

The Catalyst content client, collection pagination fetches, and cache warmer status checks now use the internal URL. Wearable and emote definition URL mapping continues to use the public URL.

## Validation

- npm run build
- npx jest test/unit/adapters/content-server-url.spec.ts test/unit/adapters/third-party-collections-cache-warmer.spec.ts --runInBand --verbose