### PR TITLE
fix: respect parcel-level updateOperator for estate parcels

### DIFF
--- a/src/adapters/parcel-rights-fetcher.ts
+++ b/src/adapters/parcel-rights-fetcher.ts
@@ -179,7 +179,8 @@ export async function createParcelRightsComponent(
     if (parcelBelongsToEstate) {
       owner = result.estates[0].owner.address
       operator = result.estates[0].operator
-      updateOperator = result.estates[0].updateOperator
+      // Parcel-level updateOperator takes precedence over estate-level (more specific)
+      updateOperator = result.parcels[0]?.updateOperator || result.estates[0].updateOperator
     } else if (result.parcels.length > 0) {
       owner = result.parcels[0].owner.address
       operator = result.parcels[0].operator

--- a/src/adapters/parcel-rights-fetcher.ts
+++ b/src/adapters/parcel-rights-fetcher.ts
@@ -180,7 +180,7 @@ export async function createParcelRightsComponent(
       owner = result.estates[0].owner.address
       operator = result.estates[0].operator
       // Parcel-level updateOperator takes precedence over estate-level (more specific)
-      updateOperator = result.parcels[0]?.updateOperator || result.estates[0].updateOperator
+      updateOperator = result.parcels[0]?.updateOperator ?? result.estates[0].updateOperator
     } else if (result.parcels.length > 0) {
       owner = result.parcels[0].owner.address
       operator = result.parcels[0].operator

--- a/test/unit/adapters/parcel-rights-fetcher.spec.ts
+++ b/test/unit/adapters/parcel-rights-fetcher.spec.ts
@@ -253,42 +253,40 @@ describe('Parcel Rights Fetcher Component', () => {
         })
       })
 
-      describe('and has a parcel-level updateOperator set via LANDRegistry.setUpdateOperator', () => {
+      describe('and the parcel has its own update operator', () => {
         const PARCEL_UPDATE_OPERATOR_ADDRESS = '0xparcelupdateoperator'
 
         beforeEach(() => {
           parcel.updateOperator = PARCEL_UPDATE_OPERATOR_ADDRESS
-          estate.updateOperator = ESTATE_UPDATE_OPERATOR_ADDRESS
         })
 
-        it('should return the parcel-level updateOperator taking precedence over the estate-level one', async () => {
-          const result = await parcelRightsFetcher.getOperatorsOfParcel(X, Y)
-          expect(result).toEqual({
-            owner: ESTATE_OWNER_ADDRESS,
-            operator: null,
-            updateOperator: PARCEL_UPDATE_OPERATOR_ADDRESS,
-            updateManagers: [],
-            approvedForAll: []
+        describe('and the estate also has an update operator', () => {
+          beforeEach(() => {
+            estate.updateOperator = ESTATE_UPDATE_OPERATOR_ADDRESS
+          })
+
+          it('should return the parcel-level update operator taking precedence over the estate-level one', async () => {
+            const result = await parcelRightsFetcher.getOperatorsOfParcel(X, Y)
+            expect(result).toEqual({
+              owner: ESTATE_OWNER_ADDRESS,
+              operator: null,
+              updateOperator: PARCEL_UPDATE_OPERATOR_ADDRESS,
+              updateManagers: [],
+              approvedForAll: []
+            })
           })
         })
-      })
 
-      describe('and has a parcel-level updateOperator but no estate-level updateOperator', () => {
-        const PARCEL_UPDATE_OPERATOR_ADDRESS = '0xparcelupdateoperator'
-
-        beforeEach(() => {
-          parcel.updateOperator = PARCEL_UPDATE_OPERATOR_ADDRESS
-          estate.updateOperator = null
-        })
-
-        it('should return the parcel-level updateOperator', async () => {
-          const result = await parcelRightsFetcher.getOperatorsOfParcel(X, Y)
-          expect(result).toEqual({
-            owner: ESTATE_OWNER_ADDRESS,
-            operator: null,
-            updateOperator: PARCEL_UPDATE_OPERATOR_ADDRESS,
-            updateManagers: [],
-            approvedForAll: []
+        describe('and the estate has no update operator', () => {
+          it('should return the parcel-level update operator', async () => {
+            const result = await parcelRightsFetcher.getOperatorsOfParcel(X, Y)
+            expect(result).toEqual({
+              owner: ESTATE_OWNER_ADDRESS,
+              operator: null,
+              updateOperator: PARCEL_UPDATE_OPERATOR_ADDRESS,
+              updateManagers: [],
+              approvedForAll: []
+            })
           })
         })
       })

--- a/test/unit/adapters/parcel-rights-fetcher.spec.ts
+++ b/test/unit/adapters/parcel-rights-fetcher.spec.ts
@@ -253,6 +253,46 @@ describe('Parcel Rights Fetcher Component', () => {
         })
       })
 
+      describe('and has a parcel-level updateOperator set via LANDRegistry.setUpdateOperator', () => {
+        const PARCEL_UPDATE_OPERATOR_ADDRESS = '0xparcelupdateoperator'
+
+        beforeEach(() => {
+          parcel.updateOperator = PARCEL_UPDATE_OPERATOR_ADDRESS
+          estate.updateOperator = ESTATE_UPDATE_OPERATOR_ADDRESS
+        })
+
+        it('should return the parcel-level updateOperator taking precedence over the estate-level one', async () => {
+          const result = await parcelRightsFetcher.getOperatorsOfParcel(X, Y)
+          expect(result).toEqual({
+            owner: ESTATE_OWNER_ADDRESS,
+            operator: null,
+            updateOperator: PARCEL_UPDATE_OPERATOR_ADDRESS,
+            updateManagers: [],
+            approvedForAll: []
+          })
+        })
+      })
+
+      describe('and has a parcel-level updateOperator but no estate-level updateOperator', () => {
+        const PARCEL_UPDATE_OPERATOR_ADDRESS = '0xparcelupdateoperator'
+
+        beforeEach(() => {
+          parcel.updateOperator = PARCEL_UPDATE_OPERATOR_ADDRESS
+          estate.updateOperator = null
+        })
+
+        it('should return the parcel-level updateOperator', async () => {
+          const result = await parcelRightsFetcher.getOperatorsOfParcel(X, Y)
+          expect(result).toEqual({
+            owner: ESTATE_OWNER_ADDRESS,
+            operator: null,
+            updateOperator: PARCEL_UPDATE_OPERATOR_ADDRESS,
+            updateManagers: [],
+            approvedForAll: []
+          })
+        })
+      })
+
       describe('and has no operator in the estate', () => {
         beforeEach(() => {
           parcel.operator = null


### PR DESCRIPTION
## Summary

- **Bug:** When a parcel belongs to an estate, `getOperatorsOfParcel` only reads `updateOperator` from the estate entity. If a user calls `LANDRegistry.setUpdateOperator(tokenId, address)` on a parcel inside an estate, the permissions endpoint incorrectly reports `updateOperator: false` because the parcel-level value is ignored.
- **Fix:** When `parcelBelongsToEstate` is true, check `result.parcels[0].updateOperator` first. The parcel-level `updateOperator` takes precedence over the estate-level one since it is more specific (set directly on the LAND token).
- **Tests:** Added two test cases covering the scenario where a parcel inside an estate has its own `updateOperator` set (both with and without an estate-level value).

## Test plan

- [x] Existing unit tests continue to pass (19/19)
- [x] New test: parcel-level updateOperator takes precedence over estate-level
- [x] New test: parcel-level updateOperator returned when estate has none

🤖 Generated with [Claude Code](https://claude.com/claude-code)