### PR TITLE
fix: cap profiles batch size to prevent amplification dos

### DIFF
--- a/src/controllers/handlers/profiles-handler.ts
+++ b/src/controllers/handlers/profiles-handler.ts
@@ -1,4 +1,5 @@
 import { HandlerContextWithPath, InvalidRequestError, NotFoundError } from '../../types'
+import { PAGINATION_DEFAULTS } from '../../logic/pagination-constants'
 import { Profile } from '@dcl/catalyst-api-specs/lib/client'
 
 export async function profilesHandler(
@@ -8,8 +9,16 @@ export async function profilesHandler(
 
   const body = await request.json()
 
-  if (!body.ids) {
+  if (!Array.isArray(body.ids) || body.ids.length === 0) {
     throw new InvalidRequestError('No profile ids were specified. Expected ids:string[] in body')
+  }
+
+  // Cap the batch size: this endpoint is public and each profile fans out to
+  // several subgraph/content lookups, so an unbounded id list is a DoS amplifier.
+  if (body.ids.length > PAGINATION_DEFAULTS.MAX_PAGE_SIZE) {
+    throw new InvalidRequestError(
+      `Too many profile ids were specified. Maximum allowed is ${PAGINATION_DEFAULTS.MAX_PAGE_SIZE}`
+    )
   }
 
   let modifiedSince: number | undefined = undefined

--- a/test/unit/profile-handlers.spec.ts
+++ b/test/unit/profile-handlers.spec.ts
@@ -118,6 +118,13 @@ describe('POST /profiles handler unit test', () => {
     expect(profilesHandler({ components, request })).rejects.toThrowError(InvalidRequestError)
   })
 
+  it('when more than the maximum allowed ids are provided it should throw InvalidRequestError', async () => {
+    const components = mockComponents(undefined)
+    const request = makeRequest({ ids: new Array(1001).fill('0x0000000000000000000000000000000000000001') })
+
+    expect(profilesHandler({ components, request })).rejects.toThrowError(InvalidRequestError)
+  })
+
   it('profiles should be returned when if-modified-since is not provided', async () => {
     const components = mockComponents([profile])
     const request = makeRequest({ ids: addresses })


### PR DESCRIPTION
## What

`POST /profiles` accepted `body.ids` with only a falsy check — no type or length validation. The endpoint is public and `getProfiles` fans out per id to several subgraph/content lookups (wearables, emotes, names, third-party ownership), so a body with hundreds of thousands of ids turns into a massive parallel outbound request storm that can exhaust sockets/memory and the subgraph quota — an unauthenticated DoS amplifier.

## Change

- Require `ids` to be a non-empty array.
- Cap the batch at `PAGINATION_DEFAULTS.MAX_PAGE_SIZE` (1000, the value already used across the service) and reject larger requests with `InvalidRequestError`.

## Verification

- `tsc --noEmit` clean; eslint clean on the changed file.
- Unit suite `profile-handlers.spec.ts`: 14 passing — added a case asserting that more than the maximum allowed ids throws `InvalidRequestError`.