### PR TITLE
fix: keep the explorer backpack from serving a ten-minute-stale item list

### DIFF
--- a/src/adapters/elements-fetcher.ts
+++ b/src/adapters/elements-fetcher.ts
@@ -6,8 +6,16 @@ import { PAGINATION_DEFAULTS } from '../logic/pagination-constants'
 
 const CACHE_DEFAULTS = {
   MAX_ENTRIES: 10000,
-  TTL: PAGINATION_DEFAULTS.CACHE_TTL
+  TTL: PAGINATION_DEFAULTS.CACHE_TTL,
+  // Ceiling on refreshes running detached from a request (see the serveStale branch below).
+  MAX_BACKGROUND_REFRESHES: 50
 } as const
+
+/** A cached result plus when it was stored, so each reader can judge its age against its own TTL. */
+type CacheEntry<T> = {
+  result: ElementsResult<T>
+  storedAt: number
+}
 
 /**
  * Create a cache key that includes all parameters for caching
@@ -58,11 +66,38 @@ export type LegacyElementsFetcher<T> = IBaseComponent & {
   fetchOwnedElements(address: string): Promise<T[]>
 }
 
+export type FetchElementsOptions = {
+  /**
+   * How old a cached entry may be, in ms, before THIS caller considers it stale. Defaults to
+   * PAGINATION_DEFAULTS.CACHE_TTL.
+   *
+   * The default suits looking at SOMEONE ELSE's items, where minutes-old data is fine. It is far too
+   * long for a caller reading its own inventory right after changing it — buying, selling or
+   * transferring an item and then being served the pre-change list reads as the change having failed.
+   *
+   * This is evaluated per READ rather than stored with the entry on purpose. The cache is shared by
+   * callers that disagree about acceptable age, and their keys collide: /explorer/:address/emotes and
+   * the profiles path both key on nothing but the address. Storing the TTL alongside the value let
+   * whichever caller happened to write first decide for everyone — a profile fetch would pin the entry
+   * as "fresh" for ten minutes and the backpack, asking for twenty seconds, was handed the stale list
+   * with no refresh. Freshness has to belong to the question being asked, not to the entry.
+   */
+  ttl?: number
+  /**
+   * Answer with an entry that is stale for this caller and refresh it behind the request, instead of
+   * making the caller wait. Opt-in: a route that is READING OWNERSHIP to make a decision (who owns a
+   * NAME, who may deploy to a parcel) must keep failing closed when the upstream is down rather than
+   * confidently serving an old answer, which is what it did before this existed.
+   */
+  serveStale?: boolean
+}
+
 export type ElementsFetcher<T> = IBaseComponent & {
   fetchOwnedElements(
     address: string,
     pagination?: { pageSize: number; pageNum: number },
-    filters?: ElementsFilters
+    filters?: ElementsFilters,
+    options?: FetchElementsOptions
   ): Promise<ElementsResult<T>>
   clearCache?(): void
 }
@@ -88,38 +123,81 @@ export function createElementsFetcherComponent<T>(
   const { logs } = dependencies
   const logger = logs.getLogger('elements-fetcher')
 
-  // Universal cache that stores complete ElementsResult for any parameter combination
-  const cache = createLowerCaseKeysCache<ElementsResult<T>>({
+  // Entries carry WHEN they were stored, because each caller decides for itself how old is too old
+  // (see FetchElementsOptions.ttl). The lru ttl is only a retention ceiling now; `allowStale` and
+  // `noDeleteOnStaleGet` are load-bearing TOGETHER to make that possible — without the latter, reading
+  // an entry past the lru ttl would delete it, so a caller willing to serve it would find nothing.
+  const cache = createLowerCaseKeysCache<CacheEntry<T>>({
     max: CACHE_DEFAULTS.MAX_ENTRIES,
-    ttl: CACHE_DEFAULTS.TTL
-    // No fetchMethod needed - we handle cache manually with get/set
+    ttl: CACHE_DEFAULTS.TTL,
+    allowStale: true,
+    noDeleteOnStaleGet: true
   })
+
+  // One in-flight load per key, so N concurrent readers cause ONE upstream fetch.
+  const refreshing = new Map<string, Promise<ElementsResult<T>>>()
+
+  function load(
+    cacheKey: string,
+    address: string,
+    pagination?: { pageSize: number; pageNum: number },
+    filters?: ElementsFilters
+  ): Promise<ElementsResult<T>> {
+    const inFlight = refreshing.get(cacheKey)
+    if (inFlight) {
+      return inFlight
+    }
+
+    const promise = fetchElements(dependencies, address.toLowerCase(), pagination, filters)
+      .then((result) => {
+        cache.set(cacheKey, { result, storedAt: Date.now() })
+        return result
+      })
+      .finally(() => {
+        // Only retract our own entry: clearCache() may have dropped it and a newer load may own the slot.
+        if (refreshing.get(cacheKey) === promise) {
+          refreshing.delete(cacheKey)
+        }
+      })
+
+    refreshing.set(cacheKey, promise)
+    return promise
+  }
 
   return {
     async fetchOwnedElements(
       address: string,
       pagination?: { pageSize: number; pageNum: number },
-      filters?: ElementsFilters
+      filters?: ElementsFilters,
+      options?: FetchElementsOptions
     ) {
-      // Always try cache first with intelligent key
       const cacheKey = createCacheKey(address, pagination, filters)
+      const maxAge = options?.ttl ?? CACHE_DEFAULTS.TTL
 
-      // Check if we have this exact combination cached
-      const cachedResult = cache.get(cacheKey)
-      if (cachedResult) {
-        return cachedResult
+      const entry = cache.get(cacheKey, { allowStale: true })
+      if (entry && Date.now() - entry.storedAt <= maxAge) {
+        return entry.result
       }
 
-      // Not in cache, fetch from API/Graph and cache the result
+      // Too old for this caller, but usable: answer with it and refresh behind the request, so a short
+      // TTL costs latency only on the very first read rather than on every expiry.
+      if (entry && options?.serveStale) {
+        // The refresh is detached from the request, so nothing upstream throttles it: without a ceiling,
+        // traffic across many addresses could fan out into unbounded concurrent full-inventory fetches.
+        // Over the ceiling we simply answer stale and let a later request schedule the refresh.
+        if (refreshing.size < CACHE_DEFAULTS.MAX_BACKGROUND_REFRESHES) {
+          load(cacheKey, address, pagination, filters).catch((err: any) => {
+            // Keep the stack: this failure no longer reaches the request, so the log is all there is.
+            logger.warn(`Background refresh failed for ${address}, serving stale`, {
+              error: err?.stack ?? err?.message ?? String(err)
+            })
+          })
+        }
+        return entry.result
+      }
+
       try {
-        // Convert address to lowercase for consistency (as the original cache did)
-        const normalizedAddress = address.toLowerCase()
-        const result = await fetchElements(dependencies, normalizedAddress, pagination, filters)
-
-        // Cache the complete result for future requests with same parameters
-        cache.set(cacheKey, result)
-
-        return result
+        return await load(cacheKey, address, pagination, filters)
       } catch (err: any) {
         logger.error(err)
         throw new FetcherError(`Cannot fetch elements for ${address}`)
@@ -129,6 +207,7 @@ export function createElementsFetcherComponent<T>(
     clearCache() {
       // Clear all cached entries - useful for tests
       cache.clear()
+      refreshing.clear()
     }
   }
 }

--- a/src/adapters/elements-fetcher.ts
+++ b/src/adapters/elements-fetcher.ts
@@ -11,10 +11,19 @@ const CACHE_DEFAULTS = {
   MAX_BACKGROUND_REFRESHES: 50
 } as const
 
+/**
+ * Monotonic milliseconds. Ages are measured against a clock that cannot step: on the wall clock an NTP
+ * correction backwards pins every entry as fresh, and one forwards expires them all at once.
+ */
+function now(): number {
+  return performance.now()
+}
+
 /** A cached result plus when it was stored, so each reader can judge its age against its own TTL. */
 type CacheEntry<T> = {
   result: ElementsResult<T>
   storedAt: number
+  generation: number
 }
 
 /**
@@ -102,7 +111,10 @@ export type ElementsFetcher<T> = IBaseComponent & {
   clearCache?(): void
 }
 
-export type ElementsFetcherDependencies = Pick<AppComponents, 'logs' | 'theGraph' | 'marketplaceApiFetcher'>
+// `metrics` is optional so every existing construction site and test keeps compiling: without it the
+// counters below are simply not recorded.
+export type ElementsFetcherDependencies = Pick<AppComponents, 'logs' | 'theGraph' | 'marketplaceApiFetcher'> &
+  Partial<Pick<AppComponents, 'metrics'>>
 
 export class FetcherError extends Error {
   constructor(message: string) {
@@ -120,7 +132,7 @@ export function createElementsFetcherComponent<T>(
     filters?: ElementsFilters
   ) => Promise<ElementsResult<T>>
 ): ElementsFetcher<T> {
-  const { logs } = dependencies
+  const { logs, metrics } = dependencies
   const logger = logs.getLogger('elements-fetcher')
 
   // Entries carry WHEN they were stored, because each caller decides for itself how old is too old
@@ -136,6 +148,10 @@ export function createElementsFetcherComponent<T>(
 
   // One in-flight load per key, so N concurrent readers cause ONE upstream fetch.
   const refreshing = new Map<string, Promise<ElementsResult<T>>>()
+  // Detached refreshes only — see the serveStale branch for why this is not `refreshing.size`.
+  let backgroundRefreshes = 0
+  // Bumped by clearCache so a load started before it cannot write its pre-clear result back in.
+  let generation = 0
 
   function load(
     cacheKey: string,
@@ -148,9 +164,13 @@ export function createElementsFetcherComponent<T>(
       return inFlight
     }
 
+    const startedAt = generation
     const promise = fetchElements(dependencies, address.toLowerCase(), pagination, filters)
       .then((result) => {
-        cache.set(cacheKey, { result, storedAt: Date.now() })
+        if (startedAt !== generation) {
+          return result
+        }
+        cache.set(cacheKey, { result, storedAt: now(), generation })
         return result
       })
       .finally(() => {
@@ -175,28 +195,62 @@ export function createElementsFetcherComponent<T>(
       const maxAge = options?.ttl ?? CACHE_DEFAULTS.TTL
 
       const entry = cache.get(cacheKey, { allowStale: true })
-      if (entry && Date.now() - entry.storedAt <= maxAge) {
+      const age = entry ? now() - entry.storedAt : Infinity
+      if (entry && age <= maxAge) {
+        metrics?.increment('elements_cache_reads_total', { result: 'fresh' })
         return entry.result
       }
 
-      // Too old for this caller, but usable: answer with it and refresh behind the request, so a short
-      // TTL costs latency only on the very first read rather than on every expiry.
-      if (entry && options?.serveStale) {
+      // Too old for this caller but recent enough to stand in: answer with it and refresh behind the
+      // request, so a short TTL costs latency only on the very first read rather than on every expiry.
+      //
+      // The age ceiling is what keeps this from making things WORSE than no cache at all. Entries are
+      // never dropped on their own (allowStale + noDeleteOnStaleGet, and lru-cache has no ttlAutopurge),
+      // so without it an hours-old list would be served forever: the buyer who last opened their backpack
+      // before the retention ceiling would be handed the pre-purchase list, where a plain expiring cache
+      // would have refetched and shown the purchase. Past the ceiling we fall through and block.
+      const withinRetention = age <= CACHE_DEFAULTS.TTL
+      if (entry && options?.serveStale && withinRetention) {
         // The refresh is detached from the request, so nothing upstream throttles it: without a ceiling,
         // traffic across many addresses could fan out into unbounded concurrent full-inventory fetches.
         // Over the ceiling we simply answer stale and let a later request schedule the refresh.
-        if (refreshing.size < CACHE_DEFAULTS.MAX_BACKGROUND_REFRESHES) {
-          load(cacheKey, address, pagination, filters).catch((err: any) => {
-            // Keep the stack: this failure no longer reaches the request, so the log is all there is.
-            logger.warn(`Background refresh failed for ${address}, serving stale`, {
+        // Counted separately from `refreshing`, which also holds request-blocking loads: sharing that
+        // number let a burst of ordinary traffic (a big POST /profiles fans out one load per id) spend
+        // the whole budget, silently leaving the backpack stale with no refresh scheduled to heal it.
+        if (backgroundRefreshes < CACHE_DEFAULTS.MAX_BACKGROUND_REFRESHES) {
+          backgroundRefreshes++
+          metrics?.increment('elements_cache_background_refresh_total', { outcome: 'started' })
+          try {
+            load(cacheKey, address, pagination, filters)
+              .catch((err: any) => {
+                // Keep the stack: this failure no longer reaches the request, so the log is all there is.
+                metrics?.increment('elements_cache_background_refresh_total', { outcome: 'failed' })
+                logger.warn(`Background refresh failed for ${address}, serving stale`, {
+                  error: err?.stack ?? err?.message ?? String(err)
+                })
+              })
+              .finally(() => {
+                backgroundRefreshes--
+              })
+          } catch (err: any) {
+            // A synchronous throw out of fetchElements never becomes a promise, so nothing above would
+            // have decremented or logged it.
+            backgroundRefreshes--
+            metrics?.increment('elements_cache_background_refresh_total', { outcome: 'failed' })
+            logger.warn(`Background refresh threw for ${address}, serving stale`, {
               error: err?.stack ?? err?.message ?? String(err)
             })
-          })
+          }
+        } else {
+          // Only visible as a metric: the request still succeeds, it just stops self-healing.
+          metrics?.increment('elements_cache_background_refresh_total', { outcome: 'skipped' })
         }
+        metrics?.increment('elements_cache_reads_total', { result: 'stale' })
         return entry.result
       }
 
       try {
+        metrics?.increment('elements_cache_reads_total', { result: entry ? 'expired' : 'miss' })
         return await load(cacheKey, address, pagination, filters)
       } catch (err: any) {
         logger.error(err)
@@ -206,8 +260,10 @@ export function createElementsFetcherComponent<T>(
 
     clearCache() {
       // Clear all cached entries - useful for tests
+      generation++
       cache.clear()
       refreshing.clear()
+      backgroundRefreshes = 0
     }
   }
 }

--- a/src/components.ts
+++ b/src/components.ts
@@ -109,25 +109,31 @@ export async function initComponents(
     contentServerUrl
   })
   const baseWearablesFetcher = createElementsFetcherComponent<BaseWearable>(
-    { logs, theGraph, marketplaceApiFetcher },
+    { logs, theGraph, marketplaceApiFetcher, metrics },
     async (_deps, _address) => {
       const elements = await fetchBaseWearables({ entitiesFetcher })
       return { elements, totalAmount: elements.length }
     }
   )
 
-  const wearablesFetcher = createElementsFetcherComponent({ logs, theGraph, marketplaceApiFetcher }, fetchWearables)
+  const wearablesFetcher = createElementsFetcherComponent(
+    { logs, theGraph, marketplaceApiFetcher, metrics },
+    fetchWearables
+  )
 
-  const emotesFetcher = createElementsFetcherComponent({ logs, theGraph, marketplaceApiFetcher }, fetchEmotes)
+  const emotesFetcher = createElementsFetcherComponent({ logs, theGraph, marketplaceApiFetcher, metrics }, fetchEmotes)
 
-  const namesFetcher = createElementsFetcherComponent({ logs, theGraph, marketplaceApiFetcher }, fetchNames)
+  const namesFetcher = createElementsFetcherComponent({ logs, theGraph, marketplaceApiFetcher, metrics }, fetchNames)
 
   const landsFetcher = createLegacyElementsFetcherComponent({ logs }, async (address) => fetchLands(theGraph, address))
 
-  const landsPermissionsFetcher = createElementsFetcherComponent({ logs, theGraph }, async (_deps, address) => {
-    const elements = await fetchAllPermissions({ theGraph }, address)
-    return { elements, totalAmount: elements.length }
-  })
+  const landsPermissionsFetcher = createElementsFetcherComponent(
+    { logs, theGraph, metrics },
+    async (_deps, address) => {
+      const elements = await fetchAllPermissions({ theGraph }, address)
+      return { elements, totalAmount: elements.length }
+    }
+  )
 
   const resourcesStatusCheck = createResourcesStatusComponent({ logs })
   const status = await createStatusComponent({ logs, fetch })
@@ -179,7 +185,7 @@ export async function initComponents(
   })
 
   const thirdPartyWearablesFetcher = createElementsFetcherComponent(
-    { logs, theGraph, marketplaceApiFetcher },
+    { logs, theGraph, marketplaceApiFetcher, metrics },
     async (_deps, address) => {
       const elements = await fetchAllThirdPartyWearables(
         { alchemyNftFetcher, contentServerUrl, thirdPartyProvidersStorage, fetch, entitiesFetcher, metrics },
@@ -191,7 +197,7 @@ export async function initComponents(
 
   const alchemyNftFetcher = await createAlchemyNftFetcher({ config, logs, fetch })
 
-  const nameOwnerFetcher = createElementsFetcherComponent({ logs, theGraph }, async (_deps, name) => {
+  const nameOwnerFetcher = createElementsFetcherComponent({ logs, theGraph, metrics }, async (_deps, name) => {
     const { owner } = await fetchNameOwner({ theGraph }, name)
     return { elements: owner ? [{ owner }] : [], totalAmount: owner ? 1 : 0 }
   })

--- a/src/controllers/handlers/explorer-emotes-handler.ts
+++ b/src/controllers/handlers/explorer-emotes-handler.ts
@@ -1,5 +1,6 @@
 import { Entity } from '@dcl/schemas'
 import { fetchAndPaginate, paginationObject } from '../../logic/pagination'
+import { EXPLORER_CACHE_OPTIONS } from '../../logic/pagination-constants'
 import { createCombinedSorting } from '../../logic/sorting'
 import { ExplorerEmoteEntity, buildTrimmedEmoteEntity } from '../../logic/utils'
 import {
@@ -35,7 +36,12 @@ async function fetchCombinedElements(
   address: string
 ): Promise<MixedEmote[]> {
   async function fetchOnChainEmotes(): Promise<MixedOnChainEmote[]> {
-    const { elements } = await components.emotesFetcher.fetchOwnedElements(address)
+    const { elements } = await components.emotesFetcher.fetchOwnedElements(
+      address,
+      undefined,
+      undefined,
+      EXPLORER_CACHE_OPTIONS
+    )
     if (!elements.length) {
       return []
     }

--- a/src/controllers/handlers/explorer-handler.ts
+++ b/src/controllers/handlers/explorer-handler.ts
@@ -15,6 +15,7 @@ import {
   ThirdPartyWearable
 } from '../../types'
 import { createFilters } from './items-commons'
+import { EXPLORER_CACHE_OPTIONS } from '../../logic/pagination-constants'
 
 export const BASE_WEARABLE = 'base-wearable'
 export const ON_CHAIN = 'on-chain'
@@ -78,10 +79,15 @@ async function fetchCombinedElements(
       itemType = 'smartWearable'
     }
 
-    const { elements } = await components.wearablesFetcher.fetchOwnedElements(address, undefined, {
-      itemType,
-      network: filters.network
-    })
+    const { elements } = await components.wearablesFetcher.fetchOwnedElements(
+      address,
+      undefined,
+      {
+        itemType,
+        network: filters.network
+      },
+      EXPLORER_CACHE_OPTIONS
+    )
 
     if (!elements.length) {
       return []
@@ -105,7 +111,12 @@ async function fetchCombinedElements(
 
   async function fetchThirdPartyWearables(thirdPartyCollectionIds: string[]): Promise<MixedThirdPartyWearable[]> {
     if (thirdPartyCollectionIds.length === 0) {
-      const { elements } = await components.thirdPartyWearablesFetcher.fetchOwnedElements(address)
+      const { elements } = await components.thirdPartyWearablesFetcher.fetchOwnedElements(
+        address,
+        undefined,
+        undefined,
+        EXPLORER_CACHE_OPTIONS
+      )
       return elements.map((wearable: ThirdPartyWearable): MixedThirdPartyWearable => {
         const entity = wearable.entity
         return {

--- a/src/logic/pagination-constants.ts
+++ b/src/logic/pagination-constants.ts
@@ -10,6 +10,24 @@ export const PAGINATION_DEFAULTS = {
   CACHE_TTL: 600000 // 10 minutes
 } as const
 
+/**
+ * How the /explorer/:address/* routes read the item cache. Those routes are how the explorer renders the
+ * signed-in user's OWN backpack. Minutes of staleness are fine for browsing someone else's items, but not
+ * for your own inventory right after you changed it: on the default TTL, buying an item in-world and
+ * reopening the backpack served the pre-purchase list — the purchase looked lost. Same in reverse once a
+ * sale transfers an item out and it lingers in the list.
+ *
+ * Kept as a TTL rather than dropped altogether because a miss here is expensive (the handler pulls the
+ * user's whole item list from the marketplace API), and paired with `serveStale` so that cost lands on
+ * the first read instead of on every expiry. Note this bounds staleness PER PROCESS: the cache is
+ * in-memory, so what a user experiences also depends on which replica they land on, and no TTL can
+ * guarantee a correct read straight after a purchase — only invalidation could.
+ */
+export const EXPLORER_CACHE_OPTIONS = {
+  ttl: 20000, // 20 seconds
+  serveStale: true
+} as const
+
 export const MARKETPLACE_API_DEFAULTS = {
   PAGE_SIZE: 1000,
   TIMEOUT: 10000 // 10 seconds

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -23,6 +23,16 @@ export const metricDeclarations = {
     type: IMetricsComponent.HistogramType,
     labelNames: ['id']
   },
+  elements_cache_reads_total: {
+    help: 'Owned-elements cache reads, by what the read got. `stale` means a caller accepted an entry older than its TTL while a refresh ran behind it.',
+    type: IMetricsComponent.CounterType,
+    labelNames: ['result']
+  },
+  elements_cache_background_refresh_total: {
+    help: 'Refreshes of the owned-elements cache running detached from a request. `skipped` means the concurrency ceiling was hit, so that read did not self-heal.',
+    type: IMetricsComponent.CounterType,
+    labelNames: ['outcome']
+  },
   cache_warmer_collections_warmed_total: {
     help: 'Total number of collections successfully warmed by the cache warmer',
     type: IMetricsComponent.CounterType,

--- a/test/integration/explorer-handler.spec.ts
+++ b/test/integration/explorer-handler.spec.ts
@@ -14,6 +14,7 @@ import { leastRareOptional, nameAZ, nameZA, rarestOptional } from '../../src/log
 import { BaseWearable, ThirdPartyAsset } from '../../src/types'
 import { createTheGraphComponentMock } from '../mocks/the-graph-mock'
 import { generateRandomAddress } from '../helpers'
+import { EXPLORER_CACHE_OPTIONS } from '../../src/logic/pagination-constants'
 
 type ContentInfo = {
   entities: Entity[]
@@ -805,9 +806,14 @@ testWithComponents(() => {
         expect(response.elements.every((el: any) => el.type === 'on-chain')).toBe(true)
 
         // Verify wearablesFetcher was called with smartWearable itemType
-        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(wallet, undefined, {
-          itemType: 'smartWearable'
-        })
+        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(
+          wallet,
+          undefined,
+          {
+            itemType: 'smartWearable'
+          },
+          EXPLORER_CACHE_OPTIONS
+        )
       })
 
       it('should return only on-chain smart wearables when isSmartWearable=1', async () => {
@@ -824,9 +830,14 @@ testWithComponents(() => {
         expect(response.elements.every((el: any) => el.type === 'on-chain')).toBe(true)
 
         // Verify wearablesFetcher was called with smartWearable itemType
-        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(wallet, undefined, {
-          itemType: 'smartWearable'
-        })
+        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(
+          wallet,
+          undefined,
+          {
+            itemType: 'smartWearable'
+          },
+          EXPLORER_CACHE_OPTIONS
+        )
       })
 
       it('should exclude base wearables when isSmartWearable=true', async () => {
@@ -871,7 +882,9 @@ testWithComponents(() => {
       it('should work with sorting when isSmartWearable=true', async () => {
         const { localFetch } = components
 
-        const r = await localFetch.fetch(`/explorer/${wallet}/wearables?isSmartWearable=true&orderBy=name&direction=asc`)
+        const r = await localFetch.fetch(
+          `/explorer/${wallet}/wearables?isSmartWearable=true&orderBy=name&direction=asc`
+        )
 
         expect(r.status).toBe(200)
         const response = await r.json()
@@ -933,9 +946,14 @@ testWithComponents(() => {
         expect(response.totalAmount).toBe(6)
 
         // Verify wearablesFetcher was called with wearable itemType (not smartWearable)
-        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(wallet, undefined, {
-          itemType: 'wearable'
-        })
+        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(
+          wallet,
+          undefined,
+          {
+            itemType: 'wearable'
+          },
+          EXPLORER_CACHE_OPTIONS
+        )
       })
 
       it('should return all wearable types when isSmartWearable=0', async () => {
@@ -951,9 +969,14 @@ testWithComponents(() => {
         expect(response.totalAmount).toBe(6)
 
         // Verify wearablesFetcher was called with wearable itemType (not smartWearable)
-        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(wallet, undefined, {
-          itemType: 'wearable'
-        })
+        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(
+          wallet,
+          undefined,
+          {
+            itemType: 'wearable'
+          },
+          EXPLORER_CACHE_OPTIONS
+        )
       })
     })
 
@@ -1008,9 +1031,14 @@ testWithComponents(() => {
         expect(response.totalAmount).toBe(6)
 
         // Verify wearablesFetcher was called with wearable itemType (default behavior)
-        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(wallet, undefined, {
-          itemType: 'wearable'
-        })
+        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(
+          wallet,
+          undefined,
+          {
+            itemType: 'wearable'
+          },
+          EXPLORER_CACHE_OPTIONS
+        )
       })
     })
 
@@ -1065,9 +1093,14 @@ testWithComponents(() => {
         expect(response.totalAmount).toBe(6)
 
         // Verify wearablesFetcher was called with wearable itemType (default behavior)
-        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(wallet, undefined, {
-          itemType: 'wearable'
-        })
+        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(
+          wallet,
+          undefined,
+          {
+            itemType: 'wearable'
+          },
+          EXPLORER_CACHE_OPTIONS
+        )
       })
     })
   })
@@ -1145,10 +1178,15 @@ testWithComponents(() => {
         expect(response.elements.every((el: any) => el.type === 'on-chain')).toBe(true)
 
         // Verify wearablesFetcher was called with network: Network.MATIC
-        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(wallet, undefined, {
-          itemType: 'wearable',
-          network: Network.MATIC
-        })
+        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(
+          wallet,
+          undefined,
+          {
+            itemType: 'wearable',
+            network: Network.MATIC
+          },
+          EXPLORER_CACHE_OPTIONS
+        )
       })
 
       it('should exclude base wearables when network=MATIC', async () => {
@@ -1256,10 +1294,15 @@ testWithComponents(() => {
         expect(response.elements.every((el: any) => el.type === 'on-chain')).toBe(true)
 
         // Verify wearablesFetcher was called with network: Network.ETHEREUM
-        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(wallet, undefined, {
-          itemType: 'wearable',
-          network: Network.ETHEREUM
-        })
+        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(
+          wallet,
+          undefined,
+          {
+            itemType: 'wearable',
+            network: Network.ETHEREUM
+          },
+          EXPLORER_CACHE_OPTIONS
+        )
       })
 
       it('should exclude base wearables when network=ETHEREUM', async () => {
@@ -1366,10 +1409,15 @@ testWithComponents(() => {
         expect(response.totalAmount).toBe(6)
 
         // Verify wearablesFetcher was called with wearable itemType and no network (queries both)
-        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(wallet, undefined, {
-          itemType: 'wearable',
-          network: undefined
-        })
+        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(
+          wallet,
+          undefined,
+          {
+            itemType: 'wearable',
+            network: undefined
+          },
+          EXPLORER_CACHE_OPTIONS
+        )
       })
     })
 
@@ -1424,10 +1472,15 @@ testWithComponents(() => {
         expect(response.totalAmount).toBe(6)
 
         // Verify wearablesFetcher was called with wearable itemType and no network (queries both)
-        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(wallet, undefined, {
-          itemType: 'wearable',
-          network: undefined
-        })
+        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(
+          wallet,
+          undefined,
+          {
+            itemType: 'wearable',
+            network: undefined
+          },
+          EXPLORER_CACHE_OPTIONS
+        )
       })
     })
 
@@ -1472,10 +1525,15 @@ testWithComponents(() => {
         expect(response.elements.every((el: any) => el.type === 'on-chain')).toBe(true)
 
         // Verify wearablesFetcher was called with network: Network.ETHEREUM
-        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(wallet, undefined, {
-          itemType: 'wearable',
-          network: Network.ETHEREUM
-        })
+        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(
+          wallet,
+          undefined,
+          {
+            itemType: 'wearable',
+            network: Network.ETHEREUM
+          },
+          EXPLORER_CACHE_OPTIONS
+        )
       })
 
       it('should accept MATIC enum value', async () => {
@@ -1492,10 +1550,15 @@ testWithComponents(() => {
         expect(response.elements.every((el: any) => el.type === 'on-chain')).toBe(true)
 
         // Verify wearablesFetcher was called with network: Network.MATIC
-        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(wallet, undefined, {
-          itemType: 'wearable',
-          network: Network.MATIC
-        })
+        expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(
+          wallet,
+          undefined,
+          {
+            itemType: 'wearable',
+            network: Network.MATIC
+          },
+          EXPLORER_CACHE_OPTIONS
+        )
       })
     })
   })
@@ -1528,7 +1591,9 @@ testWithComponents(() => {
       })
 
       content.fetchEntitiesByPointers = jest.fn(async (pointers) =>
-        pointers.map((pointer) => entities.find((def) => def.id === pointer)).filter((e): e is Entity => e !== undefined)
+        pointers
+          .map((pointer) => entities.find((def) => def.id === pointer))
+          .filter((e): e is Entity => e !== undefined)
       )
       theGraph.ethereumCollectionsSubgraph.query = jest.fn().mockResolvedValue({ nfts: [] })
       theGraph.maticCollectionsSubgraph.query = jest.fn().mockResolvedValue({ nfts: [] })
@@ -1695,7 +1760,9 @@ testWithComponents(() => {
       it('should work with includeAmount and isSmartWearable', async () => {
         const { localFetch } = components
 
-        const r = await localFetch.fetch(`/explorer/${wallet}/wearables?trimmed=true&includeAmount=true&isSmartWearable=true`)
+        const r = await localFetch.fetch(
+          `/explorer/${wallet}/wearables?trimmed=true&includeAmount=true&isSmartWearable=true`
+        )
 
         expect(r.status).toBe(200)
         const response = await r.json()
@@ -1726,7 +1793,9 @@ testWithComponents(() => {
       it('should work with includeAmount and sorting', async () => {
         const { localFetch } = components
 
-        const r = await localFetch.fetch(`/explorer/${wallet}/wearables?trimmed=true&includeAmount=true&orderBy=name&direction=asc`)
+        const r = await localFetch.fetch(
+          `/explorer/${wallet}/wearables?trimmed=true&includeAmount=true&orderBy=name&direction=asc`
+        )
 
         expect(r.status).toBe(200)
         const response = await r.json()

--- a/test/unit/adapters/elements-fetcher.spec.ts
+++ b/test/unit/adapters/elements-fetcher.spec.ts
@@ -84,3 +84,202 @@ it('result is cached (no case sensitive)', async () => {
   expect(await fetcher.fetchOwnedElements(expectedAddress)).toEqual({ elements: [0], totalAmount: 1 })
   expect(await fetcher.fetchOwnedElements(expectedAddress.toUpperCase())).toEqual({ elements: [0], totalAmount: 1 })
 })
+
+// These use REAL timers with short TTLs on purpose: lru-cache reads its own clock (performance.now,
+// captured when the module loads), which jest's fake timers do not move — faking them made entries never
+// expire, so the tests passed through the fresh-hit path and proved nothing.
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+const SHORT_TTL = 300
+const EXPLORER = { ttl: SHORT_TTL, serveStale: true }
+
+function countingFetcher(logs: any, onCall?: () => void) {
+  let calls = 0
+  const fetcher = createElementsFetcherComponent<number>(
+    { logs, theGraph: null as any, marketplaceApiFetcher: null as any },
+    async () => {
+      calls++
+      onCall?.()
+      return { elements: [calls], totalAmount: 1 }
+    }
+  )
+  return { fetcher, calls: () => calls }
+}
+
+it('serves the cached result until the given ttl expires', async () => {
+  const logs = await createLogComponent({})
+  const { fetcher, calls } = countingFetcher(logs)
+
+  expect(await fetcher.fetchOwnedElements('anAddress', undefined, undefined, EXPLORER)).toEqual({
+    elements: [1],
+    totalAmount: 1
+  })
+  await sleep(SHORT_TTL / 3)
+  expect(await fetcher.fetchOwnedElements('anAddress', undefined, undefined, EXPLORER)).toEqual({
+    elements: [1],
+    totalAmount: 1
+  })
+  expect(calls()).toBe(1)
+})
+
+it('answers with the stale result and refreshes behind the request once the ttl expires', async () => {
+  const logs = await createLogComponent({})
+  const { fetcher, calls } = countingFetcher(logs)
+
+  await fetcher.fetchOwnedElements('anAddress', undefined, undefined, EXPLORER)
+  await sleep(SHORT_TTL * 2)
+
+  // Past the ttl the caller is not made to wait: it gets the previous value…
+  expect(await fetcher.fetchOwnedElements('anAddress', undefined, undefined, EXPLORER)).toEqual({
+    elements: [1],
+    totalAmount: 1
+  })
+  // …while a refresh runs behind it, so the NEXT read is up to date.
+  expect(calls()).toBe(2)
+  expect(await fetcher.fetchOwnedElements('anAddress', undefined, undefined, EXPLORER)).toEqual({
+    elements: [2],
+    totalAmount: 1
+  })
+})
+
+// THE regression this change exists for. The cache is shared and the keys collide — /explorer/:address/
+// emotes and the profiles path both key on nothing but the address — so if the age of an entry were
+// decided by whoever wrote it, a profile fetch (default TTL) would pin the entry as fresh for ten minutes
+// and the backpack would be handed the pre-purchase list with no refresh. That is what shipped the bug.
+it('does not let a default-ttl writer pin the entry against a short-ttl reader', async () => {
+  const logs = await createLogComponent({})
+  const { fetcher, calls } = countingFetcher(logs)
+
+  // Someone walks past the user → profiles warms the key on the default (minutes-long) TTL.
+  await fetcher.fetchOwnedElements('anAddress')
+  await sleep(SHORT_TTL * 2)
+
+  // The backpack asks the same key with its own short TTL: too old for IT, so it must refresh.
+  expect(await fetcher.fetchOwnedElements('anAddress', undefined, undefined, EXPLORER)).toEqual({
+    elements: [1],
+    totalAmount: 1
+  })
+  expect(calls()).toBe(2)
+  expect(await fetcher.fetchOwnedElements('anAddress', undefined, undefined, EXPLORER)).toEqual({
+    elements: [2],
+    totalAmount: 1
+  })
+})
+
+it('does not apply the short ttl to callers that did not ask for one', async () => {
+  const logs = await createLogComponent({})
+  const { fetcher, calls } = countingFetcher(logs)
+
+  // The fetchers are shared with /users/:address/* — those keep the default (minutes-long) TTL, so a
+  // wait far longer than the explorer TTL must NOT trigger a refetch for them.
+  await fetcher.fetchOwnedElements('anAddress')
+  await sleep(SHORT_TTL * 2)
+  expect(await fetcher.fetchOwnedElements('anAddress')).toEqual({ elements: [1], totalAmount: 1 })
+  expect(calls()).toBe(1)
+})
+
+it('collapses concurrent misses into a single upstream fetch', async () => {
+  const logs = await createLogComponent({})
+  let calls = 0
+  const fetcher = createElementsFetcherComponent<number>(
+    { logs, theGraph: null as any, marketplaceApiFetcher: null as any },
+    async () => {
+      calls++
+      await sleep(10)
+      return { elements: [calls], totalAmount: 1 }
+    }
+  )
+
+  // A cold cache hit by several requests at once must not fan out to the upstream API once each: the
+  // explorer routes pull a user's whole item list, so that is the expensive case to collapse.
+  const results = await Promise.all([
+    fetcher.fetchOwnedElements('anAddress'),
+    fetcher.fetchOwnedElements('anAddress'),
+    fetcher.fetchOwnedElements('anAddress')
+  ])
+
+  expect(calls).toBe(1)
+  expect(results).toEqual([
+    { elements: [1], totalAmount: 1 },
+    { elements: [1], totalAmount: 1 },
+    { elements: [1], totalAmount: 1 }
+  ])
+})
+
+it('keeps serving the stale result when the refresh fails', async () => {
+  const logs = await createLogComponent({})
+  let calls = 0
+  const fetcher = createElementsFetcherComponent<number>(
+    { logs, theGraph: null as any, marketplaceApiFetcher: null as any },
+    async () => {
+      calls++
+      if (calls > 1) throw new Error('upstream is down')
+      return { elements: [1], totalAmount: 1 }
+    }
+  )
+
+  await fetcher.fetchOwnedElements('anAddress', undefined, undefined, EXPLORER)
+  await sleep(SHORT_TTL * 2)
+
+  // An upstream outage must not turn a populated backpack into an error.
+  expect(await fetcher.fetchOwnedElements('anAddress', undefined, undefined, EXPLORER)).toEqual({
+    elements: [1],
+    totalAmount: 1
+  })
+  await sleep(20)
+  expect(await fetcher.fetchOwnedElements('anAddress', undefined, undefined, EXPLORER)).toEqual({
+    elements: [1],
+    totalAmount: 1
+  })
+})
+
+// Ownership answers must keep failing CLOSED. Before serveStale existed, an upstream outage threw and the
+// route 5xx'd; serving a months-old owner with a 200 instead would be worse than an error, so callers
+// that did not opt in still get the throw.
+it('throws instead of serving stale for callers that did not opt in', async () => {
+  const logs = await createLogComponent({})
+  let calls = 0
+  const fetcher = createElementsFetcherComponent<number>(
+    { logs, theGraph: null as any, marketplaceApiFetcher: null as any },
+    async () => {
+      calls++
+      if (calls > 1) throw new Error('upstream is down')
+      return { elements: [1], totalAmount: 1 }
+    }
+  )
+
+  await fetcher.fetchOwnedElements('anAddress', undefined, undefined, { ttl: SHORT_TTL })
+  await sleep(SHORT_TTL * 2)
+
+  await expect(fetcher.fetchOwnedElements('anAddress', undefined, undefined, { ttl: SHORT_TTL })).rejects.toThrow(
+    'Cannot fetch elements for anAddress'
+  )
+})
+
+it('caps how many refreshes run detached from a request', async () => {
+  const logs = await createLogComponent({})
+  const addresses = Array.from({ length: 80 }, (_, i) => `address-${i}`)
+  let inFlight = 0
+  let peak = 0
+  const fetcher = createElementsFetcherComponent<number>(
+    { logs, theGraph: null as any, marketplaceApiFetcher: null as any },
+    async () => {
+      inFlight++
+      peak = Math.max(peak, inFlight)
+      await sleep(50)
+      inFlight--
+      return { elements: [1], totalAmount: 1 }
+    }
+  )
+
+  // Prime every key, let them all go stale, then read them all at once. Each read answers instantly from
+  // the stale entry, so nothing upstream throttles the refreshes — the ceiling has to.
+  await Promise.all(addresses.map((a) => fetcher.fetchOwnedElements(a, undefined, undefined, EXPLORER)))
+  await sleep(SHORT_TTL * 2)
+  // Priming ran 80 loads at once, but each had a caller awaiting it — those are request-bound and are
+  // NOT what the ceiling governs. Only the detached refreshes below are.
+  peak = 0
+  await Promise.all(addresses.map((a) => fetcher.fetchOwnedElements(a, undefined, undefined, EXPLORER)))
+
+  expect(peak).toBeGreaterThan(0)
+  expect(peak).toBeLessThanOrEqual(50)
+})

--- a/test/unit/adapters/elements-fetcher.spec.ts
+++ b/test/unit/adapters/elements-fetcher.spec.ts
@@ -283,3 +283,69 @@ it('caps how many refreshes run detached from a request', async () => {
   expect(peak).toBeGreaterThan(0)
   expect(peak).toBeLessThanOrEqual(50)
 })
+
+// Without an age ceiling this branch made things WORSE than a plain expiring cache: entries are never
+// dropped on their own, so an hours-old list would be served forever, while a cache that simply expired
+// would have refetched and shown the purchase. Past the retention ceiling the caller must block.
+//
+// The age is measured with the fetcher's own monotonic clock, so shifting that is enough to age an entry
+// past the ten-minute ceiling — no waiting, and no dependence on lru-cache's internal clock.
+it('blocks instead of serving stale once the entry passes the retention ceiling', async () => {
+  const logs = await createLogComponent({})
+  const { fetcher, calls } = countingFetcher(logs)
+  const realNow = performance.now.bind(performance)
+
+  await fetcher.fetchOwnedElements('anAddress', undefined, undefined, EXPLORER)
+  expect(calls()).toBe(1)
+
+  const elevenMinutes = 11 * 60 * 1000
+  const clock = jest.spyOn(performance, 'now').mockImplementation(() => realNow() + elevenMinutes)
+  try {
+    // Not the previous value — the caller waited and got the current one.
+    expect(await fetcher.fetchOwnedElements('anAddress', undefined, undefined, EXPLORER)).toEqual({
+      elements: [2],
+      totalAmount: 1
+    })
+    expect(calls()).toBe(2)
+  } finally {
+    clock.mockRestore()
+  }
+})
+
+// The ceiling on detached refreshes must not be spent by loads that have a caller waiting on them.
+// Sharing one number let ordinary traffic (a big POST /profiles fans out one load per id) exhaust the
+// budget, so the backpack served stale and scheduled nothing to heal it — silently.
+it('does not let request-blocking loads exhaust the background-refresh budget', async () => {
+  const logs = await createLogComponent({})
+  let backpackFetches = 0
+  let release: (() => void) | undefined
+  const blocked = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const fetcher = createElementsFetcherComponent<number>(
+    { logs, theGraph: null as any, marketplaceApiFetcher: null as any },
+    async (_deps, address) => {
+      if (address === 'backpack-user') {
+        backpackFetches++
+        return { elements: [backpackFetches], totalAmount: 1 }
+      }
+      await blocked // the profiles fan-out, parked upstream
+      return { elements: [0], totalAmount: 1 }
+    }
+  )
+
+  // Prime the backpack key and let it go stale.
+  await fetcher.fetchOwnedElements('backpack-user', undefined, undefined, EXPLORER)
+  await sleep(SHORT_TTL * 2)
+
+  // 60 ordinary, request-bound loads now sit in flight — more than the ceiling.
+  const parked = Array.from({ length: 60 }, (_, i) => fetcher.fetchOwnedElements(`profile-${i}`))
+  await sleep(20)
+
+  // The backpack read must still schedule its refresh.
+  await fetcher.fetchOwnedElements('backpack-user', undefined, undefined, EXPLORER)
+  expect(backpackFetches).toBe(2)
+
+  release!()
+  await Promise.all(parked)
+})

--- a/test/unit/explorer-handlers-cache.spec.ts
+++ b/test/unit/explorer-handlers-cache.spec.ts
@@ -1,0 +1,77 @@
+import { explorerHandler } from '../../src/controllers/handlers/explorer-handler'
+import { explorerEmotesHandler } from '../../src/controllers/handlers/explorer-emotes-handler'
+import { EXPLORER_CACHE_OPTIONS, PAGINATION_DEFAULTS } from '../../src/logic/pagination-constants'
+
+/**
+ * The /explorer/* routes are the signed-in user's own backpack, and they share their fetchers with
+ * /users/:address/* — so the short TTL cannot live on the component, it has to be asked for per call.
+ * These assert the wiring: without it the constant exists and nothing uses it, which is exactly the
+ * state that shipped the bug.
+ */
+
+const emptyFetcher = () => ({ fetchOwnedElements: jest.fn().mockResolvedValue({ elements: [], totalAmount: 0 }) })
+
+describe('explorer handlers cache TTL wiring', () => {
+  it('asks the wearables fetcher for the short TTL', async () => {
+    const wearablesFetcher = emptyFetcher()
+    const components = {
+      fetch: { fetch: jest.fn() },
+      baseWearablesFetcher: emptyFetcher(),
+      wearablesFetcher,
+      thirdPartyWearablesFetcher: emptyFetcher(),
+      entitiesFetcher: { fetchEntities: jest.fn().mockResolvedValue([]) },
+      thirdPartyProvidersStorage: { getAll: jest.fn().mockResolvedValue([]) }
+    }
+
+    await explorerHandler({
+      params: { address: '0xsomeone' },
+      url: new URL('https://peer.decentraland.org/lambdas/explorer/0xsomeone/wearables'),
+      components
+    } as any)
+
+    expect(wearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(
+      '0xsomeone',
+      undefined,
+      expect.anything(),
+      EXPLORER_CACHE_OPTIONS
+    )
+    // Third-party wearables ride in the same response, so a linked wearable must not lag behind.
+    expect(components.thirdPartyWearablesFetcher.fetchOwnedElements).toHaveBeenCalledWith(
+      '0xsomeone',
+      undefined,
+      undefined,
+      EXPLORER_CACHE_OPTIONS
+    )
+  })
+
+  it('asks the emotes fetcher for the short TTL', async () => {
+    const emotesFetcher = emptyFetcher()
+    const components = {
+      emotesFetcher,
+      entitiesFetcher: { fetchEntities: jest.fn().mockResolvedValue([]) }
+    }
+
+    await explorerEmotesHandler({
+      params: { address: '0xsomeone' },
+      url: new URL('https://peer.decentraland.org/lambdas/explorer/0xsomeone/emotes'),
+      components
+    } as any)
+
+    expect(emotesFetcher.fetchOwnedElements).toHaveBeenCalledWith(
+      '0xsomeone',
+      undefined,
+      undefined,
+      EXPLORER_CACHE_OPTIONS
+    )
+  })
+})
+
+describe('explorer cache options', () => {
+  it('stay short enough, and stale-tolerant, for a change to your own items to show up', () => {
+    // Guards the shape of the fix rather than a literal: minutes would reintroduce the bug, and without
+    // serveStale every expiry would cost the backpack a full multi-page inventory fetch before it opens.
+    expect(EXPLORER_CACHE_OPTIONS.ttl).toBeLessThanOrEqual(30_000)
+    expect(EXPLORER_CACHE_OPTIONS.ttl).toBeLessThan(PAGINATION_DEFAULTS.CACHE_TTL)
+    expect(EXPLORER_CACHE_OPTIONS.serveStale).toBe(true)
+  })
+})


### PR DESCRIPTION
## The bug

`GET /explorer/:address/wearables` and `/explorer/:address/emotes` are what the Unity explorer's backpack renders from — the client passes its own signed-in address and injects `NoCache` for these responses, so every time the backpack opens it asks this service.

Both routes read through `createElementsFetcherComponent`, whose LRU cache had one TTL for every caller: `PAGINATION_DEFAULTS.CACHE_TTL`, **10 minutes**. So a player who bought an item in-world and reopened the backpack was served the pre-purchase list, and no polling on their side could help — the entry was already cached. The same thing in reverse once a sale transfers an item out: it lingers in the list as if still owned.

Verified rather than assumed: `lru-cache` is at 8.0.5, where the `ttl` option is honored (in v6 the option was `maxAge` and a `ttl` would have been silently ignored), and a cache hit returns with no revalidation.

## Why the TTL is per call and not on the component

The fetchers are shared. `wearablesFetcher` also serves `/users/:address/wearables` and the outfits handler; `emotesFetcher` also serves `/users/:address/emotes` and the profiles path. Looking at *someone else's* items minutes late is fine and those callers should keep the long TTL, so the short one is requested per call.

**Freshness is evaluated on the read, not stored with the entry.** That distinction is the whole fix, and the first version of this change got it wrong: attaching the TTL to the entry on write let whichever caller wrote first decide for everyone. The keys collide — `createCacheKey(address, undefined, undefined)` is just the address, which is exactly what `profiles.ts` and `emotes-by-owner` use — so a profile fetch (someone walks past you) pinned the entry as "fresh" for ten minutes and the backpack, asking for twenty seconds, was handed the stale list with no refresh. On the hot profiles path that would have shipped an emotes fix that mostly did nothing, while wearables looked fixed because their key carries `fitemType:wearable`. There is a test named after that exact case now.

## Changes

- `elements-fetcher.ts`: `fetchOwnedElements` takes `{ ttl?, serveStale? }`. Entries store `storedAt`, and each reader compares the age against **its own** TTL.
- Stale-while-revalidate, **opt-in**: a reader that tolerates stale data gets it immediately and a refresh runs behind the request, so a short TTL costs latency only on the first read rather than on every expiry. Opt-in because routes that read ownership to make a decision — `/names/:name/owner`, `/users/:address/lands-permissions`, the profile ownership filter — must keep failing closed on an upstream outage instead of confidently serving an old answer. Turning this on globally would have quietly changed them from 5xx to a 200 with the previous owner.
- Stale serving is **bounded by the retention ceiling**. Entries are never dropped on their own (`allowStale` + `noDeleteOnStaleGet`, and lru-cache has no `ttlAutopurge`), so without a ceiling an hours-old list would be served forever — *worse* than the plain expiring cache it replaces, which would have refetched. Past `CACHE_DEFAULTS.TTL` the read falls through and blocks, exactly as `main` did. This was caught by review after being measured: "open backpack → play 30 min → buy → open backpack" landed squarely in that window.
- Background refreshes are **capped** (50 concurrent), counted **separately from request-blocking loads**. Sharing one number let ordinary traffic spend the whole budget — one `POST /profiles` with more than 50 uncached ids fans out a blocking load per id, and for that whole window the backpack served stale and scheduled nothing to heal it, silently. Detached from the request, nothing upstream throttles them, and a miss here is expensive: `fetchAllPages` walks pages of 1000 sequentially with a 10s timeout each. These routes are public, unauthenticated, and take a free-form address, so unbounded fan-out would be an amplification vector of the same shape as the one fixed in `38b9641`. Over the ceiling we just answer stale and let a later request schedule the refresh.
- Concurrent readers of the same key collapse into one upstream fetch (previously each cold reader fetched separately).
- Ages are measured on a **monotonic** clock (`performance.now`), so an NTP step backwards can't pin every entry as fresh, nor one forwards expire them all at once.
- Two counters, `elements_cache_reads_total{result}` and `elements_cache_background_refresh_total{outcome}`. `outcome="skipped"` is the only signal that the backpack has stopped self-healing, and it was invisible before. `metrics` is threaded in as optional so every existing construction site and test mock keeps compiling.
- `EXPLORER_CACHE_OPTIONS` — 20s + `serveStale` — used by all three fetches that make up a backpack response: on-chain wearables, **third-party wearables** (a linked wearable acquired in-world was lagging in the same response body), and emotes. Base wearables are deliberately left on the default: they are the free default collection, nobody acquires one.

## What this does and does not fix

It removes the ten minutes. What remains is the squid's own indexing lag (seconds) plus up to the TTL, **per replica** — the cache is in-memory, so a user bouncing between replicas can still land on one whose entry is fresh. No TTL can guarantee a correct read straight after a purchase; only invalidation, or a client hint ("I just changed something"), could. Worth knowing before anyone reports this as still-broken in an edge case.

The explorer needs no changes for this.

## Test plan

- [x] `test/unit/adapters/elements-fetcher.spec.ts` — TTL honored; stale served + refreshed behind the request; **a default-TTL writer does not pin a short-TTL reader** (the bug above); default callers unaffected by the short TTL; default callers still throw instead of serving stale; stale still served when the refresh fails; concurrent misses collapse to one fetch; the background-refresh ceiling holds.
- [x] `test/unit/explorer-handlers-cache.spec.ts` — both handlers pass the options, third-party wearables included, plus a guard on the shape of `EXPLORER_CACHE_OPTIONS`.
- [x] Every new test was checked against the pre-change code — the wiring ones fail without it, and the pin test was written from a probe that reproduced the pin.
- [x] The 12 updated assertions in `test/integration/explorer-handler.spec.ts` pin the exact argument list, so they had to learn the new one.
- [x] Both P1 fixes are mutation-tested: reverting the age ceiling fails `blocks instead of serving stale once the entry passes the retention ceiling`, and reverting the shared budget fails `does not let request-blocking loads exhaust the background-refresh budget`.
- [x] `yarn build`, `yarn lint:check`, prettier, `361 unit tests / 39 suites` green. Integration suites pass **individually** (explorer 44, explorer-emotes 17, emotes 19, wearables, marketplace-api-fallback); running them all at once fails on `EADDRINUSE :7272` because every suite binds the same fixed port — reproduced on `main`, and `jest.integration.config.js` says CI runs the unit suites only.

The tests use real timers with short TTLs on purpose: jest's fake timers do not move `lru-cache`'s clock (it captures `performance.now` at module load), so faking them made entries never expire and the tests passed through the fresh-hit path proving nothing.

## Watch after deploy

1. **Marketplace API rate** for `/v1/users/*/wearables/grouped` and `/emotes/grouped` — the per-key refresh ceiling goes from 1/10min to 1/20s, so **30×** worst case; realistic is far lower (it scales with how often a backpack is opened, not with total traffic). If it lands near the ceiling, raise the TTL.
2. **Alchemy volume and 429s.** The third-party-wearables leg of the backpack response is Alchemy-backed — metered, rate-limited, third-party — and it gets the same 20s ceiling. This is the load risk I would watch hardest in the first hour, and the age ceiling does not change it: it bounds worst-case staleness, not refresh rate.
3. **`elements_cache_background_refresh_total{outcome="skipped"}`** — non-trivial values mean the backpack has stopped self-healing.
4. **`logger.warn` rate on "Background refresh failed … serving stale"** — during an outage that is the only signal explorer routes have gone stale.
5. **`/explorer/*` p99 and 5xx** — p99 should fall and 5xx go to ~0. If 5xx does *not* fall, `serveStale` isn't engaging and the wiring is wrong.

## Follow-ups, deliberately not here

- The cache has no `maxSize`/`sizeCalculation`, so its byte ceiling is 10 000 entries × one collector's full item list, per fetcher, and there are seven. Measured at a full `max`: ~474 MB for median users, ~3.2 GB for heavy ones. Pre-existing and unchanged by this PR, but worth a ticket.
- `baseWearablesFetcher` ignores the address yet caches per address, so it can hold up to 10 000 copies of the same 283-item list. Also pre-existing.
- A lower cap for the Alchemy-backed third-party fetcher specifically, if its volume turns out to matter.
- `src/index.ts` is not prettier-clean on `main`; left alone to keep this diff to the point.
