### PR TITLE
fix: batch entities requests to stay under the content server pointers limit

### DIFF
--- a/src/adapters/definitions-fetcher.ts
+++ b/src/adapters/definitions-fetcher.ts
@@ -36,7 +36,7 @@ async function createDefinitionsFetcherComponent<T extends WearableDefinition | 
       if (nonCachedURNs.length !== 0) {
         const entities = await fetchEntitiesInBatches(
           nonCachedURNs,
-          (batch) => content.fetchEntitiesByPointers(batch),
+          (batch, { abortController }) => content.fetchEntitiesByPointers(batch, { abortController }),
           logger
         )
 
@@ -46,9 +46,18 @@ async function createDefinitionsFetcherComponent<T extends WearableDefinition | 
             continue
           }
 
-          const definition = entityMapper({ contentServerUrl }, entity)
-          itemDefinitionsCache.set(definition.id, definition)
-          definitionsByUrn.set(definition.id, definition)
+          try {
+            const definition = entityMapper({ contentServerUrl }, entity)
+            itemDefinitionsCache.set(definition.id, definition)
+            definitionsByUrn.set(definition.id, definition)
+          } catch (error) {
+            // The mapper reads nested metadata, so one malformed entity must not cost the
+            // definitions of every other item in the request.
+            logger.warn('Skipping entity that could not be mapped to a definition', {
+              entityId: entity.id,
+              error: error instanceof Error ? error.message : 'Unknown error'
+            })
+          }
         }
       }
 

--- a/src/adapters/definitions-fetcher.ts
+++ b/src/adapters/definitions-fetcher.ts
@@ -4,19 +4,21 @@ import { AppComponents } from '../types'
 import { extractEmoteDefinitionFromEntity, extractWearableDefinitionFromEntity } from './definitions'
 import { createLowerCaseKeysCache } from './lowercase-keys-cache'
 import { createLowerCaseKeysMap } from './lowercase-keys-map'
+import { fetchEntitiesInBatches } from '../logic/fetch-entities-in-batches'
 
 export type DefinitionsFetcher<T extends WearableDefinition | EmoteDefinition> = IBaseComponent & {
   fetchItemsDefinitions(urns: string[]): Promise<(T | undefined)[]>
 }
 
 async function createDefinitionsFetcherComponent<T extends WearableDefinition | EmoteDefinition>(
-  { config, content, contentServerUrl }: Pick<AppComponents, 'logs' | 'config' | 'content' | 'contentServerUrl'>,
+  { config, content, contentServerUrl, logs }: Pick<AppComponents, 'logs' | 'config' | 'content' | 'contentServerUrl'>,
   entityMapper: (components: Pick<AppComponents, 'contentServerUrl'>, entity: Entity) => T
 ): Promise<DefinitionsFetcher<T>> {
   const itemsSize = (await config.getNumber('ITEMS_CACHE_MAX_SIZE')) ?? 10000
   const itemsAge = (await config.getNumber('ITEMS_CACHE_MAX_AGE')) ?? 600000 // 10 minutes by default
 
   const itemDefinitionsCache = createLowerCaseKeysCache<T>({ max: itemsSize, ttl: itemsAge })
+  const logger = logs.getLogger('definitions-fetcher')
 
   return {
     async fetchItemsDefinitions(urns: string[]): Promise<(T | undefined)[]> {
@@ -32,8 +34,18 @@ async function createDefinitionsFetcherComponent<T extends WearableDefinition | 
       }
 
       if (nonCachedURNs.length !== 0) {
-        const entities = await content.fetchEntitiesByPointers(nonCachedURNs)
+        const entities = await fetchEntitiesInBatches(
+          nonCachedURNs,
+          (batch) => content.fetchEntitiesByPointers(batch),
+          logger
+        )
+
         for (const entity of entities) {
+          if (!entity?.metadata?.id) {
+            logger.warn('Skipping entity without metadata id', { entityId: entity?.id ?? '<unknown>' })
+            continue
+          }
+
           const definition = entityMapper({ contentServerUrl }, entity)
           itemDefinitionsCache.set(definition.id, definition)
           definitionsByUrn.set(definition.id, definition)

--- a/src/adapters/entities-fetcher.ts
+++ b/src/adapters/entities-fetcher.ts
@@ -94,7 +94,7 @@ export async function createEntitiesFetcherComponent({
     if (nonCachedURNs.length !== 0) {
       const entities = await fetchEntitiesInBatches(
         nonCachedURNs,
-        (batch) => content.fetchEntitiesByPointers(batch),
+        (batch, { abortController }) => content.fetchEntitiesByPointers(batch, { abortController }),
         logger
       )
 

--- a/src/adapters/entities-fetcher.ts
+++ b/src/adapters/entities-fetcher.ts
@@ -3,6 +3,7 @@ import { AppComponents } from '../types'
 import { Entity, Mappings } from '@dcl/schemas'
 import { createLowerCaseKeysCache } from './lowercase-keys-cache'
 import { createLowerCaseKeysMap } from './lowercase-keys-map'
+import { fetchEntitiesInBatches } from '../logic/fetch-entities-in-batches'
 import { filterByUserNfts } from '../logic/linked-wearables-mapper'
 
 /**
@@ -33,13 +34,6 @@ export type EntitiesFetcher = IBaseComponent & {
 
 const MAX_COLLECTION_PAGE_SIZE = 1000
 const TWO_DAYS_IN_MS = 48 * 60 * 60 * 1000
-
-/**
- * The content server validates `POST /entities/active` against a JSON schema that caps
- * `pointers` at 1000 items, answering 400 when it is exceeded. Requests are split into
- * batches below that cap so wallets owning more items than the limit can still be resolved.
- */
-const MAX_POINTERS_PER_REQUEST = 500
 
 export async function createEntitiesFetcherComponent({
   config,
@@ -98,17 +92,16 @@ export async function createEntitiesFetcherComponent({
     }
 
     if (nonCachedURNs.length !== 0) {
-      const batches: string[][] = []
-      for (let i = 0; i < nonCachedURNs.length; i += MAX_POINTERS_PER_REQUEST) {
-        batches.push(nonCachedURNs.slice(i, i + MAX_POINTERS_PER_REQUEST))
-      }
+      const entities = await fetchEntitiesInBatches(
+        nonCachedURNs,
+        (batch) => content.fetchEntitiesByPointers(batch),
+        logger
+      )
 
-      const fetchedBatches = await Promise.all(batches.map((batch) => content.fetchEntitiesByPointers(batch)))
-
-      for (const entity of fetchedBatches.flat()) {
-        const urn = entity.metadata?.id
+      for (const entity of entities) {
+        const urn = entity?.metadata?.id
         if (!urn) {
-          logger.warn('Skipping entity without metadata id', { entityId: entity.id })
+          logger.warn('Skipping entity without metadata id', { entityId: entity?.id ?? '<unknown>' })
           continue
         }
 

--- a/src/adapters/entities-fetcher.ts
+++ b/src/adapters/entities-fetcher.ts
@@ -34,6 +34,13 @@ export type EntitiesFetcher = IBaseComponent & {
 const MAX_COLLECTION_PAGE_SIZE = 1000
 const TWO_DAYS_IN_MS = 48 * 60 * 60 * 1000
 
+/**
+ * The content server validates `POST /entities/active` against a JSON schema that caps
+ * `pointers` at 1000 items, answering 400 when it is exceeded. Requests are split into
+ * batches below that cap so wallets owning more items than the limit can still be resolved.
+ */
+const MAX_POINTERS_PER_REQUEST = 500
+
 export async function createEntitiesFetcherComponent({
   config,
   content,
@@ -91,10 +98,22 @@ export async function createEntitiesFetcherComponent({
     }
 
     if (nonCachedURNs.length !== 0) {
-      const entities = await content.fetchEntitiesByPointers(nonCachedURNs)
-      for (const entity of entities) {
-        entititesCache.set(entity.metadata.id, entity)
-        entitiesByUrn.set(entity.metadata.id, entity)
+      const batches: string[][] = []
+      for (let i = 0; i < nonCachedURNs.length; i += MAX_POINTERS_PER_REQUEST) {
+        batches.push(nonCachedURNs.slice(i, i + MAX_POINTERS_PER_REQUEST))
+      }
+
+      const fetchedBatches = await Promise.all(batches.map((batch) => content.fetchEntitiesByPointers(batch)))
+
+      for (const entity of fetchedBatches.flat()) {
+        const urn = entity.metadata?.id
+        if (!urn) {
+          logger.warn('Skipping entity without metadata id', { entityId: entity.id })
+          continue
+        }
+
+        entititesCache.set(urn, entity)
+        entitiesByUrn.set(urn, entity)
       }
     }
 

--- a/src/controllers/handlers/profiles-handler.ts
+++ b/src/controllers/handlers/profiles-handler.ts
@@ -15,6 +15,8 @@ export async function profilesHandler(
 
   // Cap the batch size: this endpoint is public and each profile fans out to
   // several subgraph/content lookups, so an unbounded id list is a DoS amplifier.
+  // This cap must stay at or below the content server's 1000-pointer limit on
+  // POST /entities/active: `profiles.getProfiles` sends the ids there unbatched.
   if (body.ids.length > PAGINATION_DEFAULTS.MAX_PAGE_SIZE) {
     throw new InvalidRequestError(
       `Too many profile ids were specified. Maximum allowed is ${PAGINATION_DEFAULTS.MAX_PAGE_SIZE}`

--- a/src/logic/fetch-entities-in-batches.ts
+++ b/src/logic/fetch-entities-in-batches.ts
@@ -11,19 +11,30 @@ export const MAX_POINTERS_PER_REQUEST = 900
 /**
  * Batches run concurrently but bounded: the cap above exists to keep the underlying
  * `ANY(...)` query cheap on a public endpoint, so one request for a wallet with many items
- * must not fan out into an unbounded burst of those queries.
+ * must not fan out into an unbounded burst of those queries. The bound is per call, so
+ * concurrent requests still add up; a process-wide limit would need a shared semaphore.
  */
 export const MAX_CONCURRENT_POINTER_REQUESTS = 4
 
+/** Thrown when a batch fails, after the batches still in flight have been cancelled. */
+export class EntityBatchFailedError extends Error {
+  constructor(public readonly reason: unknown) {
+    super(`Failed to fetch a batch of entities: ${reason instanceof Error ? reason.message : 'Unknown error'}`)
+  }
+}
+
 /**
  * Resolves pointers through `fetchBatch` in batches small enough for the content server to
- * accept, with bounded concurrency. A batch that fails costs only its own entities: the
- * returned array holds whatever resolved, since callers already treat an unresolved pointer
- * as a miss.
+ * accept, with bounded concurrency. Entities come back in completion order, not pointer
+ * order, so callers must key them rather than zip them against the input.
+ *
+ * A result missing entities is indistinguishable from a wallet that owns nothing, so any
+ * failing batch fails the whole call: the shared abort controller cancels the batches still
+ * in flight, and the original failure is reported rather than the cancellations it caused.
  */
 export async function fetchEntitiesInBatches(
   pointers: string[],
-  fetchBatch: (batch: string[]) => Promise<Entity[]>,
+  fetchBatch: (batch: string[], options: { abortController: AbortController }) => Promise<Entity[]>,
   logger: ILoggerComponent.ILogger
 ): Promise<Entity[]> {
   const batches: string[][] = []
@@ -32,25 +43,42 @@ export async function fetchEntitiesInBatches(
   }
 
   const entities: Entity[] = []
+  const abortController = new AbortController()
   let nextBatch = 0
+  let firstError: unknown
 
   async function worker(): Promise<void> {
-    while (nextBatch < batches.length) {
+    while (nextBatch < batches.length && !abortController.signal.aborted) {
       const batch = batches[nextBatch++]
 
       try {
-        entities.push(...(await fetchBatch(batch)))
+        entities.push(...(await fetchBatch(batch, { abortController })))
       } catch (error) {
-        logger.warn('Failed to fetch a batch of entities', {
-          pointers: batch.length,
-          error: error instanceof Error ? error.message : 'Unknown error'
-        })
+        // Keep the first failure: the batches cancelled below reject with an abort error
+        // that would otherwise bury the reason the call failed.
+        if (!abortController.signal.aborted) {
+          firstError = error
+          abortController.abort()
+        }
+
+        throw error
       }
     }
   }
 
   const workers = Math.min(MAX_CONCURRENT_POINTER_REQUESTS, batches.length)
-  await Promise.all(Array.from({ length: workers }, () => worker()))
+
+  try {
+    await Promise.all(Array.from({ length: workers }, () => worker()))
+  } catch (error) {
+    const reason = firstError ?? error
+    logger.warn('Cancelled the remaining entity batches after one of them failed', {
+      batches: batches.length,
+      error: reason instanceof Error ? reason.message : 'Unknown error'
+    })
+
+    throw new EntityBatchFailedError(reason)
+  }
 
   return entities
 }

--- a/src/logic/fetch-entities-in-batches.ts
+++ b/src/logic/fetch-entities-in-batches.ts
@@ -67,10 +67,14 @@ export async function fetchEntitiesInBatches(
   }
 
   const workers = Math.min(MAX_CONCURRENT_POINTER_REQUESTS, batches.length)
+  const workerPromises = Array.from({ length: workers }, () => worker())
 
   try {
-    await Promise.all(Array.from({ length: workers }, () => worker()))
+    await Promise.all(workerPromises)
   } catch (error) {
+    // Aborting only signals the other requests to stop. Wait until every worker
+    // has observed the signal and finished cleaning up before returning.
+    await Promise.allSettled(workerPromises)
     const reason = firstError ?? error
     logger.warn('Cancelled the remaining entity batches after one of them failed', {
       batches: batches.length,

--- a/src/logic/fetch-entities-in-batches.ts
+++ b/src/logic/fetch-entities-in-batches.ts
@@ -1,0 +1,56 @@
+import { Entity } from '@dcl/schemas'
+import { ILoggerComponent } from '@well-known-components/interfaces'
+
+/**
+ * The content server validates `POST /entities/active` against a JSON schema that caps
+ * `pointers` at 1000 items, answering 400 when it is exceeded. Batches stay under that cap
+ * with headroom so wallets owning more items than the limit can still be resolved.
+ */
+export const MAX_POINTERS_PER_REQUEST = 900
+
+/**
+ * Batches run concurrently but bounded: the cap above exists to keep the underlying
+ * `ANY(...)` query cheap on a public endpoint, so one request for a wallet with many items
+ * must not fan out into an unbounded burst of those queries.
+ */
+export const MAX_CONCURRENT_POINTER_REQUESTS = 4
+
+/**
+ * Resolves pointers through `fetchBatch` in batches small enough for the content server to
+ * accept, with bounded concurrency. A batch that fails costs only its own entities: the
+ * returned array holds whatever resolved, since callers already treat an unresolved pointer
+ * as a miss.
+ */
+export async function fetchEntitiesInBatches(
+  pointers: string[],
+  fetchBatch: (batch: string[]) => Promise<Entity[]>,
+  logger: ILoggerComponent.ILogger
+): Promise<Entity[]> {
+  const batches: string[][] = []
+  for (let index = 0; index < pointers.length; index += MAX_POINTERS_PER_REQUEST) {
+    batches.push(pointers.slice(index, index + MAX_POINTERS_PER_REQUEST))
+  }
+
+  const entities: Entity[] = []
+  let nextBatch = 0
+
+  async function worker(): Promise<void> {
+    while (nextBatch < batches.length) {
+      const batch = batches[nextBatch++]
+
+      try {
+        entities.push(...(await fetchBatch(batch)))
+      } catch (error) {
+        logger.warn('Failed to fetch a batch of entities', {
+          pointers: batch.length,
+          error: error instanceof Error ? error.message : 'Unknown error'
+        })
+      }
+    }
+  }
+
+  const workers = Math.min(MAX_CONCURRENT_POINTER_REQUESTS, batches.length)
+  await Promise.all(Array.from({ length: workers }, () => worker()))
+
+  return entities
+}

--- a/test/integration/explorer-handler.spec.ts
+++ b/test/integration/explorer-handler.spec.ts
@@ -308,6 +308,60 @@ testWithComponents(() => {
     expect(response12.elements).toHaveLength(2)
   })
 
+  it('return on-chain wearables for a wallet owning more items than the content server pointers limit', async () => {
+    const { content, fetch, localFetch, theGraph, baseWearablesFetcher, wearablesFetcher, alchemyNftFetcher } =
+      components
+
+    // The content server validates `POST /entities/active` with `pointers` capped at 1000
+    // items and answers 400 when exceeded. Asking for every owned entity in one request
+    // made that 400 surface as a 500, leaving the backpack empty for these wallets.
+    const CONTENT_SERVER_POINTERS_LIMIT = 1000
+    // The entities cache lives in the components shared by the whole suite, so these urns are
+    // namespaced to keep the assertions on the issued requests independent of the other tests.
+    const onChainWearables = generateWearables(CONTENT_SERVER_POINTERS_LIMIT + 1).map((wearable, index) => ({
+      ...wearable,
+      urn: `urn-over-limit-${index}`
+    }))
+    const entities = generateWearableEntities(onChainWearables.map((wearable) => wearable.urn))
+    const entitiesByUrn = new Map(entities.map((entity) => [entity.id, entity]))
+
+    alchemyNftFetcher.getNFTsForOwner = jest.fn().mockResolvedValue([])
+    baseWearablesFetcher.fetchOwnedElements = jest.fn().mockResolvedValue({ elements: [], totalAmount: 0 })
+    wearablesFetcher.fetchOwnedElements = jest.fn().mockResolvedValue({
+      elements: convertWearablesToOnChain(onChainWearables),
+      totalAmount: onChainWearables.length
+    })
+    content.fetchEntitiesByPointers = jest.fn(async (pointers) => {
+      if (pointers.length > CONTENT_SERVER_POINTERS_LIMIT) {
+        throw new Error(`Invalid JSON body: pointers must NOT have more than ${CONTENT_SERVER_POINTERS_LIMIT} items`)
+      }
+      return pointers.map((pointer) => entitiesByUrn.get(pointer))
+    })
+    theGraph.ethereumCollectionsSubgraph.query = jest.fn().mockResolvedValue({ nfts: [] })
+    theGraph.maticCollectionsSubgraph.query = jest.fn().mockResolvedValue({ nfts: [] })
+    fetch.fetch = jest.fn().mockResolvedValue({ ok: true, json: () => ({ entities: [] }) })
+
+    const wallet = generateRandomAddress()
+    const r = await localFetch.fetch(`/explorer/${wallet}/wearables?pageNum=1&pageSize=16&collectionType=on-chain`)
+
+    expect(r.status).toBe(200)
+    const response = await r.json()
+    expect(response).toMatchObject({
+      pageNum: 1,
+      pageSize: 16,
+      totalAmount: onChainWearables.length
+    })
+    expect(response.elements).toHaveLength(16)
+
+    // Every owned wearable is resolved, and no single request goes over the limit
+    const requestedPointers = (content.fetchEntitiesByPointers as jest.Mock).mock.calls.map((call) => call[0])
+    expect(requestedPointers.length).toBeGreaterThan(1)
+    for (const pointers of requestedPointers) {
+      expect(pointers.length).toBeLessThanOrEqual(CONTENT_SERVER_POINTERS_LIMIT)
+    }
+    expect(requestedPointers.flat().sort()).toEqual(onChainWearables.map((wearable) => wearable.urn).sort())
+  })
+
   it('return trimmed response when trimmed=true parameter is provided', async () => {
     const { content, fetch, localFetch, theGraph, baseWearablesFetcher, wearablesFetcher, alchemyNftFetcher } =
       components

--- a/test/integration/wearables-by-owner-handler.spec.ts
+++ b/test/integration/wearables-by-owner-handler.spec.ts
@@ -106,4 +106,59 @@ testWith('wearables-by-owner-handler: GET /collections/wearables-by-owner/:owner
       }
     })
   })
+
+  describe('and the owner has more items than the content server pointers limit', () => {
+    // Definitions are resolved for every owned item at once, so this path hit the same
+    // 400-over-1000-pointers wall as /explorer/:address/wearables and answered 500.
+    const CONTENT_SERVER_POINTERS_LIMIT = 1000
+
+    let address: string
+    let ownedUrns: string[]
+    let requestedPointers: string[][]
+    let response: Awaited<ReturnType<typeof components.localFetch.fetch>>
+    let body: Array<{ urn: string; definition?: { id: string } }>
+    // The definitions cache lives in the components shared by the whole suite, so each test
+    // needs its own urns to actually exercise the requests instead of reading them back.
+    let run = 0
+
+    beforeEach(async () => {
+      run++
+      ownedUrns = Array.from(
+        { length: CONTENT_SERVER_POINTERS_LIMIT + 1 },
+        (_, index) => `urn:by-owner-over-limit:${run}:${index}`
+      )
+      components.wearablesFetcher.fetchOwnedElements = jest.fn().mockResolvedValue({
+        elements: ownedUrns.map((urn) => ({ urn, amount: 1, individualData: [{ id: `${urn}:0` }] })),
+        totalAmount: ownedUrns.length
+      })
+      components.content.fetchEntitiesByPointers = jest.fn(async (urns: string[]) => {
+        if (urns.length > CONTENT_SERVER_POINTERS_LIMIT) {
+          throw new Error(`Invalid JSON body: pointers must NOT have more than ${CONTENT_SERVER_POINTERS_LIMIT} items`)
+        }
+        return urns.map((urn) => buildWearableEntity(urn, `def-${urn}`))
+      })
+      address = generateRandomAddress()
+      response = await components.localFetch.fetch(`/collections/wearables-by-owner/${address}?includeDefinitions`)
+      body = (await response.json()) as typeof body
+      requestedPointers = (components.content.fetchEntitiesByPointers as jest.Mock).mock.calls.map((call) => call[0])
+    })
+
+    it('should respond 200 instead of failing on the pointers limit', () => {
+      expect(response.status).toBe(200)
+    })
+
+    it('should keep every content request within the pointers limit', () => {
+      expect(requestedPointers.length).toBeGreaterThan(1)
+      for (const pointers of requestedPointers) {
+        expect(pointers.length).toBeLessThanOrEqual(CONTENT_SERVER_POINTERS_LIMIT)
+      }
+    })
+
+    it('should resolve a definition for every owned item', () => {
+      expect(body).toHaveLength(ownedUrns.length)
+      for (const entry of body) {
+        expect(entry.definition).toMatchObject({ id: entry.urn })
+      }
+    })
+  })
 })

--- a/test/unit/adapters/definitions-fetcher.spec.ts
+++ b/test/unit/adapters/definitions-fetcher.spec.ts
@@ -1,8 +1,26 @@
-import { Emote, EntityType, Wearable } from "@dcl/schemas"
+import { Emote, Entity, EntityType, Wearable, WearableDefinition } from "@dcl/schemas"
 import { createDotEnvConfigComponent } from "@well-known-components/env-config-provider"
 import { createLogComponent } from "@well-known-components/logger"
 import { createEmoteDefinitionsFetcherComponent, createWearableDefinitionsFetcherComponent } from "../../../src/adapters/definitions-fetcher"
 import { createContentClientMock } from "../../mocks/content-mock"
+
+function buildWearableEntity(urn: string): Entity {
+  return {
+    version: 'v3',
+    id: `entity-${urn}`,
+    type: EntityType.WEARABLE,
+    pointers: [urn],
+    timestamp: 0,
+    content: [{ file: 'thumbnail.png', hash: 'thumbnailId' }],
+    metadata: {
+      id: urn,
+      data: { tags: [], representations: [{ contents: ['thumbnail.png'] }] },
+      thumbnail: 'thumbnail.png',
+      image: 'image.png',
+      description: 'aDescription'
+    } as Wearable
+  }
+}
 
 it('wearables are fetched and mapped to WearableDefinition', async () => {
   const contentMock = createContentClientMock()
@@ -245,4 +263,51 @@ it('definitions are fetched despite being evicted from cache', async () => {
     expect.objectContaining({ id: 'UrN:wearable:0' }),
     expect.objectContaining({ id: 'UrN:wearable:1' })
   ]))
+})
+
+describe('when fetching more urns than the content server pointers limit', () => {
+  // Definitions are resolved for every owned item at once, so a wallet above the limit made
+  // the content server answer 400 and the request fail as a 500.
+  const CONTENT_SERVER_POINTERS_LIMIT = 1000
+
+  let contentMock: ReturnType<typeof createContentClientMock>
+  let urns: string[]
+  let definitions: (WearableDefinition | undefined)[]
+  let requestedPointers: string[][]
+
+  beforeEach(async () => {
+    urns = Array.from({ length: CONTENT_SERVER_POINTERS_LIMIT + 1 }, (_, index) => `urn:wearable:${index}`)
+    contentMock = createContentClientMock()
+    contentMock.fetchEntitiesByPointers = jest.fn(async (pointers: string[]) => {
+      if (pointers.length > CONTENT_SERVER_POINTERS_LIMIT) {
+        throw new Error(`Invalid JSON body: pointers must NOT have more than ${CONTENT_SERVER_POINTERS_LIMIT} items`)
+      }
+      return pointers.map(buildWearableEntity)
+    })
+
+    const wearableDefinitionsFetcher = await createWearableDefinitionsFetcherComponent({
+      config: await createDotEnvConfigComponent({ path: ['.env.default', '.env'] }),
+      logs: await createLogComponent({}),
+      content: contentMock,
+      contentServerUrl: 'baseUrl'
+    })
+
+    definitions = await wearableDefinitionsFetcher.fetchItemsDefinitions(urns)
+    requestedPointers = (contentMock.fetchEntitiesByPointers as jest.Mock).mock.calls.map((call) => call[0])
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should split the work into batches the content server accepts', () => {
+    expect(requestedPointers.length).toBeGreaterThan(1)
+    for (const pointers of requestedPointers) {
+      expect(pointers.length).toBeLessThanOrEqual(CONTENT_SERVER_POINTERS_LIMIT)
+    }
+  })
+
+  it('should resolve a definition for every urn, aligned with the requested order', () => {
+    expect(definitions.map((definition) => definition?.id)).toEqual(urns)
+  })
 })

--- a/test/unit/adapters/definitions-fetcher.spec.ts
+++ b/test/unit/adapters/definitions-fetcher.spec.ts
@@ -311,3 +311,42 @@ describe('when fetching more urns than the content server pointers limit', () =>
     expect(definitions.map((definition) => definition?.id)).toEqual(urns)
   })
 })
+
+describe('when an entity cannot be mapped to a definition', () => {
+  let contentMock: ReturnType<typeof createContentClientMock>
+  let definitions: (WearableDefinition | undefined)[]
+
+  beforeEach(async () => {
+    contentMock = createContentClientMock()
+    const malformed = buildWearableEntity('urn:wearable:malformed')
+    // A wearable whose metadata carries an id but no `data` makes the mapper throw.
+    delete (malformed.metadata as Partial<Wearable>).data
+    contentMock.fetchEntitiesByPointers = jest
+      .fn()
+      .mockResolvedValue([malformed, buildWearableEntity('urn:wearable:sound')])
+
+    const wearableDefinitionsFetcher = await createWearableDefinitionsFetcherComponent({
+      config: await createDotEnvConfigComponent({ path: ['.env.default', '.env'] }),
+      logs: await createLogComponent({}),
+      content: contentMock,
+      contentServerUrl: 'baseUrl'
+    })
+
+    definitions = await wearableDefinitionsFetcher.fetchItemsDefinitions([
+      'urn:wearable:malformed',
+      'urn:wearable:sound'
+    ])
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should report the unmappable entity as a miss', () => {
+    expect(definitions[0]).toBeUndefined()
+  })
+
+  it('should still map the entities alongside it instead of failing the whole request', () => {
+    expect(definitions[1]?.id).toBe('urn:wearable:sound')
+  })
+})

--- a/test/unit/adapters/entities-fetcher.spec.ts
+++ b/test/unit/adapters/entities-fetcher.spec.ts
@@ -54,7 +54,9 @@ describe('when fetching fewer urns than the content server pointers limit', () =
 
   it('should resolve them in a single request', () => {
     expect(content.fetchEntitiesByPointers).toHaveBeenCalledTimes(1)
-    expect(content.fetchEntitiesByPointers).toHaveBeenCalledWith(urns)
+    expect(content.fetchEntitiesByPointers).toHaveBeenCalledWith(urns, {
+      abortController: expect.any(AbortController)
+    })
   })
 
   it('should return one entity per urn, aligned with the requested order', () => {

--- a/test/unit/adapters/entities-fetcher.spec.ts
+++ b/test/unit/adapters/entities-fetcher.spec.ts
@@ -1,0 +1,102 @@
+import { Entity, EntityType } from '@dcl/schemas'
+import { createDotEnvConfigComponent } from '@well-known-components/env-config-provider'
+import { createLogComponent } from '@well-known-components/logger'
+import { createEntitiesFetcherComponent } from '../../../src/adapters/entities-fetcher'
+import { createContentClientMock } from '../../mocks/content-mock'
+
+// Keep in sync with MAX_POINTERS_PER_REQUEST in src/adapters/entities-fetcher.ts
+const MAX_POINTERS_PER_REQUEST = 500
+
+function generateEntity(urn: string): Entity {
+  return {
+    version: 'v3',
+    id: `entity-${urn}`,
+    type: EntityType.WEARABLE,
+    pointers: [urn],
+    timestamp: 0,
+    content: [],
+    metadata: { id: urn }
+  }
+}
+
+async function createFetcher(content: ReturnType<typeof createContentClientMock>) {
+  const logs = await createLogComponent({})
+  const config = await createDotEnvConfigComponent({ path: ['.env.default', '.env'] })
+  const fetch = { fetch: jest.fn() }
+
+  return createEntitiesFetcherComponent({
+    config,
+    logs,
+    content,
+    internalContentServerUrl: 'internalContentServerUrl',
+    fetch
+  })
+}
+
+it('fetches entities in a single request when under the pointers limit', async () => {
+  const urns = Array.from({ length: 10 }, (_, i) => `urn:wearable:${i}`)
+  const content = createContentClientMock()
+  content.fetchEntitiesByPointers = jest.fn(async (pointers: string[]) => pointers.map(generateEntity))
+
+  const entitiesFetcher = await createFetcher(content)
+  const entities = await entitiesFetcher.fetchEntities(urns)
+
+  expect(content.fetchEntitiesByPointers).toHaveBeenCalledTimes(1)
+  expect(content.fetchEntitiesByPointers).toHaveBeenCalledWith(urns)
+  expect(entities.map((entity) => entity?.metadata.id)).toEqual(urns)
+})
+
+it('splits the request in batches when over the pointers limit, so the content server does not reject it', async () => {
+  // A wallet owning this many items used to produce a single request the content server
+  // answered with 400 (`pointers` maxItems is 1000), which surfaced as a 500 to the client.
+  const urns = Array.from({ length: 1939 }, (_, i) => `urn:wearable:${i}`)
+  const content = createContentClientMock()
+  content.fetchEntitiesByPointers = jest.fn(async (pointers: string[]) => {
+    if (pointers.length > 1000) {
+      throw new Error('Invalid JSON body: pointers must NOT have more than 1000 items')
+    }
+    return pointers.map(generateEntity)
+  })
+
+  const entitiesFetcher = await createFetcher(content)
+  const entities = await entitiesFetcher.fetchEntities(urns)
+
+  expect(content.fetchEntitiesByPointers).toHaveBeenCalledTimes(Math.ceil(urns.length / MAX_POINTERS_PER_REQUEST))
+  for (const call of (content.fetchEntitiesByPointers as jest.Mock).mock.calls) {
+    expect(call[0].length).toBeLessThanOrEqual(MAX_POINTERS_PER_REQUEST)
+  }
+
+  // Every urn is resolved, in the requested order, with no duplicates or holes
+  expect(entities).toHaveLength(urns.length)
+  expect(entities.map((entity) => entity?.metadata.id)).toEqual(urns)
+})
+
+it('only requests the urns missing from the cache', async () => {
+  const urns = Array.from({ length: 600 }, (_, i) => `urn:wearable:${i}`)
+  const content = createContentClientMock()
+  content.fetchEntitiesByPointers = jest.fn(async (pointers: string[]) => pointers.map(generateEntity))
+
+  const entitiesFetcher = await createFetcher(content)
+  await entitiesFetcher.fetchEntities(urns)
+  ;(content.fetchEntitiesByPointers as jest.Mock).mockClear()
+
+  const entities = await entitiesFetcher.fetchEntities(urns)
+
+  expect(content.fetchEntitiesByPointers).not.toHaveBeenCalled()
+  expect(entities.map((entity) => entity?.metadata.id)).toEqual(urns)
+})
+
+it('skips entities without a metadata id instead of failing the whole request', async () => {
+  const urns = ['urn:wearable:0', 'urn:wearable:1']
+  const content = createContentClientMock()
+  content.fetchEntitiesByPointers = jest.fn(async () => [
+    generateEntity('urn:wearable:0'),
+    { ...generateEntity('urn:wearable:1'), metadata: undefined }
+  ])
+
+  const entitiesFetcher = await createFetcher(content)
+  const entities = await entitiesFetcher.fetchEntities(urns)
+
+  expect(entities[0]?.metadata.id).toBe('urn:wearable:0')
+  expect(entities[1]).toBeUndefined()
+})

--- a/test/unit/adapters/entities-fetcher.spec.ts
+++ b/test/unit/adapters/entities-fetcher.spec.ts
@@ -1,11 +1,11 @@
 import { Entity, EntityType } from '@dcl/schemas'
 import { createDotEnvConfigComponent } from '@well-known-components/env-config-provider'
 import { createLogComponent } from '@well-known-components/logger'
-import { createEntitiesFetcherComponent } from '../../../src/adapters/entities-fetcher'
+import { EntitiesFetcher, createEntitiesFetcherComponent } from '../../../src/adapters/entities-fetcher'
+import { MAX_POINTERS_PER_REQUEST } from '../../../src/logic/fetch-entities-in-batches'
 import { createContentClientMock } from '../../mocks/content-mock'
 
-// Keep in sync with MAX_POINTERS_PER_REQUEST in src/adapters/entities-fetcher.ts
-const MAX_POINTERS_PER_REQUEST = 500
+const CONTENT_SERVER_POINTERS_LIMIT = 1000
 
 function generateEntity(urn: string): Entity {
   return {
@@ -19,84 +19,122 @@ function generateEntity(urn: string): Entity {
   }
 }
 
-async function createFetcher(content: ReturnType<typeof createContentClientMock>) {
-  const logs = await createLogComponent({})
-  const config = await createDotEnvConfigComponent({ path: ['.env.default', '.env'] })
-  const fetch = { fetch: jest.fn() }
+function generateUrns(quantity: number): string[] {
+  return Array.from({ length: quantity }, (_, index) => `urn:wearable:${index}`)
+}
 
+async function createFetcher(content: ReturnType<typeof createContentClientMock>): Promise<EntitiesFetcher> {
   return createEntitiesFetcherComponent({
-    config,
-    logs,
+    config: await createDotEnvConfigComponent({ path: ['.env.default', '.env'] }),
+    logs: await createLogComponent({}),
     content,
     internalContentServerUrl: 'internalContentServerUrl',
-    fetch
+    fetch: { fetch: jest.fn() }
   })
 }
 
-it('fetches entities in a single request when under the pointers limit', async () => {
-  const urns = Array.from({ length: 10 }, (_, i) => `urn:wearable:${i}`)
-  const content = createContentClientMock()
-  content.fetchEntitiesByPointers = jest.fn(async (pointers: string[]) => pointers.map(generateEntity))
+let content: ReturnType<typeof createContentClientMock>
+let entitiesFetcher: EntitiesFetcher
 
-  const entitiesFetcher = await createFetcher(content)
-  const entities = await entitiesFetcher.fetchEntities(urns)
-
-  expect(content.fetchEntitiesByPointers).toHaveBeenCalledTimes(1)
-  expect(content.fetchEntitiesByPointers).toHaveBeenCalledWith(urns)
-  expect(entities.map((entity) => entity?.metadata.id)).toEqual(urns)
+afterEach(() => {
+  jest.resetAllMocks()
 })
 
-it('splits the request in batches when over the pointers limit, so the content server does not reject it', async () => {
-  // A wallet owning this many items used to produce a single request the content server
-  // answered with 400 (`pointers` maxItems is 1000), which surfaced as a 500 to the client.
-  const urns = Array.from({ length: 1939 }, (_, i) => `urn:wearable:${i}`)
-  const content = createContentClientMock()
-  content.fetchEntitiesByPointers = jest.fn(async (pointers: string[]) => {
-    if (pointers.length > 1000) {
-      throw new Error('Invalid JSON body: pointers must NOT have more than 1000 items')
-    }
-    return pointers.map(generateEntity)
+describe('when fetching fewer urns than the content server pointers limit', () => {
+  let urns: string[]
+  let entities: (Entity | undefined)[]
+
+  beforeEach(async () => {
+    urns = generateUrns(10)
+    content = createContentClientMock()
+    content.fetchEntitiesByPointers = jest.fn(async (pointers: string[]) => pointers.map(generateEntity))
+    entitiesFetcher = await createFetcher(content)
+    entities = await entitiesFetcher.fetchEntities(urns)
   })
 
-  const entitiesFetcher = await createFetcher(content)
-  const entities = await entitiesFetcher.fetchEntities(urns)
+  it('should resolve them in a single request', () => {
+    expect(content.fetchEntitiesByPointers).toHaveBeenCalledTimes(1)
+    expect(content.fetchEntitiesByPointers).toHaveBeenCalledWith(urns)
+  })
 
-  expect(content.fetchEntitiesByPointers).toHaveBeenCalledTimes(Math.ceil(urns.length / MAX_POINTERS_PER_REQUEST))
-  for (const call of (content.fetchEntitiesByPointers as jest.Mock).mock.calls) {
-    expect(call[0].length).toBeLessThanOrEqual(MAX_POINTERS_PER_REQUEST)
-  }
-
-  // Every urn is resolved, in the requested order, with no duplicates or holes
-  expect(entities).toHaveLength(urns.length)
-  expect(entities.map((entity) => entity?.metadata.id)).toEqual(urns)
+  it('should return one entity per urn, aligned with the requested order', () => {
+    expect(entities.map((entity) => entity?.metadata.id)).toEqual(urns)
+  })
 })
 
-it('only requests the urns missing from the cache', async () => {
-  const urns = Array.from({ length: 600 }, (_, i) => `urn:wearable:${i}`)
-  const content = createContentClientMock()
-  content.fetchEntitiesByPointers = jest.fn(async (pointers: string[]) => pointers.map(generateEntity))
+describe('when fetching more urns than the content server pointers limit', () => {
+  let urns: string[]
+  let entities: (Entity | undefined)[]
 
-  const entitiesFetcher = await createFetcher(content)
-  await entitiesFetcher.fetchEntities(urns)
-  ;(content.fetchEntitiesByPointers as jest.Mock).mockClear()
+  beforeEach(async () => {
+    // A wallet owning this many items produced a single request the content server answered
+    // with 400 (`pointers` maxItems is 1000), surfacing as a 500 to the client.
+    urns = generateUrns(1939)
+    content = createContentClientMock()
+    content.fetchEntitiesByPointers = jest.fn(async (pointers: string[]) => {
+      if (pointers.length > CONTENT_SERVER_POINTERS_LIMIT) {
+        throw new Error(`Invalid JSON body: pointers must NOT have more than ${CONTENT_SERVER_POINTERS_LIMIT} items`)
+      }
+      return pointers.map(generateEntity)
+    })
+    entitiesFetcher = await createFetcher(content)
+    entities = await entitiesFetcher.fetchEntities(urns)
+  })
 
-  const entities = await entitiesFetcher.fetchEntities(urns)
+  it('should split the work into batches the content server accepts', () => {
+    for (const call of (content.fetchEntitiesByPointers as jest.Mock).mock.calls) {
+      expect(call[0].length).toBeLessThanOrEqual(MAX_POINTERS_PER_REQUEST)
+    }
+  })
 
-  expect(content.fetchEntitiesByPointers).not.toHaveBeenCalled()
-  expect(entities.map((entity) => entity?.metadata.id)).toEqual(urns)
+  it('should resolve every urn, in the requested order, with no holes', () => {
+    expect(entities.map((entity) => entity?.metadata.id)).toEqual(urns)
+  })
 })
 
-it('skips entities without a metadata id instead of failing the whole request', async () => {
-  const urns = ['urn:wearable:0', 'urn:wearable:1']
-  const content = createContentClientMock()
-  content.fetchEntitiesByPointers = jest.fn(async () => [
-    generateEntity('urn:wearable:0'),
-    { ...generateEntity('urn:wearable:1'), metadata: undefined }
-  ])
+describe('when the same urns are fetched twice', () => {
+  let urns: string[]
+  let entities: (Entity | undefined)[]
 
-  const entitiesFetcher = await createFetcher(content)
-  const entities = await entitiesFetcher.fetchEntities(urns)
+  beforeEach(async () => {
+    urns = generateUrns(600)
+    content = createContentClientMock()
+    content.fetchEntitiesByPointers = jest.fn(async (pointers: string[]) => pointers.map(generateEntity))
+    entitiesFetcher = await createFetcher(content)
+    await entitiesFetcher.fetchEntities(urns)
+    ;(content.fetchEntitiesByPointers as jest.Mock).mockClear()
+    entities = await entitiesFetcher.fetchEntities(urns)
+  })
 
-  expect(entities[0]?.metadata.id).toBe('urn:wearable:0')
-  expect(entities[1]).toBeUndefined()
+  it('should serve the second call from the cache without requesting anything', () => {
+    expect(content.fetchEntitiesByPointers).not.toHaveBeenCalled()
+  })
+
+  it('should still return every entity', () => {
+    expect(entities.map((entity) => entity?.metadata.id)).toEqual(urns)
+  })
+})
+
+describe('when the content server returns an entity without metadata', () => {
+  let urns: string[]
+  let entities: (Entity | undefined)[]
+
+  beforeEach(async () => {
+    urns = ['urn:wearable:0', 'urn:wearable:1']
+    content = createContentClientMock()
+    content.fetchEntitiesByPointers = jest.fn(async () => [
+      generateEntity('urn:wearable:0'),
+      { ...generateEntity('urn:wearable:1'), metadata: undefined }
+    ])
+    entitiesFetcher = await createFetcher(content)
+    entities = await entitiesFetcher.fetchEntities(urns)
+  })
+
+  it('should still return the entities that could be keyed by urn', () => {
+    expect(entities[0]?.metadata.id).toBe('urn:wearable:0')
+  })
+
+  it('should report the unusable entity as a miss instead of failing the request', () => {
+    expect(entities[1]).toBeUndefined()
+  })
 })

--- a/test/unit/logic/fetch-entities-in-batches.spec.ts
+++ b/test/unit/logic/fetch-entities-in-batches.spec.ts
@@ -1,0 +1,161 @@
+import { Entity, EntityType } from '@dcl/schemas'
+import { ILoggerComponent } from '@well-known-components/interfaces'
+import {
+  MAX_CONCURRENT_POINTER_REQUESTS,
+  MAX_POINTERS_PER_REQUEST,
+  fetchEntitiesInBatches
+} from '../../../src/logic/fetch-entities-in-batches'
+
+function generateEntity(urn: string): Entity {
+  return {
+    version: 'v3',
+    id: `entity-${urn}`,
+    type: EntityType.WEARABLE,
+    pointers: [urn],
+    timestamp: 0,
+    content: [],
+    metadata: { id: urn }
+  }
+}
+
+function generatePointers(quantity: number): string[] {
+  return Array.from({ length: quantity }, (_, index) => `urn:wearable:${index}`)
+}
+
+let logger: ILoggerComponent.ILogger
+let fetchBatch: jest.Mock
+
+beforeEach(() => {
+  logger = { log: jest.fn(), debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('when the pointers fit in a single batch', () => {
+  let pointers: string[]
+  let entities: Entity[]
+
+  beforeEach(async () => {
+    pointers = generatePointers(10)
+    fetchBatch = jest.fn(async (batch: string[]) => batch.map(generateEntity))
+    entities = await fetchEntitiesInBatches(pointers, fetchBatch, logger)
+  })
+
+  it('should issue a single request holding every pointer', () => {
+    expect(fetchBatch).toHaveBeenCalledTimes(1)
+    expect(fetchBatch).toHaveBeenCalledWith(pointers)
+  })
+
+  it('should return one entity per pointer', () => {
+    expect(entities.map((entity) => entity.metadata.id)).toEqual(pointers)
+  })
+})
+
+describe('when the pointers exceed the maximum per request', () => {
+  let pointers: string[]
+  let entities: Entity[]
+  let requestedBatches: string[][]
+
+  beforeEach(async () => {
+    // The content server answers 400 above 1000 pointers, so a wallet this size used to
+    // fail outright instead of being split.
+    pointers = generatePointers(1939)
+    fetchBatch = jest.fn(async (batch: string[]) => {
+      if (batch.length > 1000) {
+        throw new Error('Invalid JSON body: pointers must NOT have more than 1000 items')
+      }
+      return batch.map(generateEntity)
+    })
+    entities = await fetchEntitiesInBatches(pointers, fetchBatch, logger)
+    requestedBatches = fetchBatch.mock.calls.map((call) => call[0])
+  })
+
+  it('should split the pointers into one request per batch', () => {
+    expect(fetchBatch).toHaveBeenCalledTimes(Math.ceil(pointers.length / MAX_POINTERS_PER_REQUEST))
+  })
+
+  it('should keep every request within the maximum per request', () => {
+    for (const batch of requestedBatches) {
+      expect(batch.length).toBeLessThanOrEqual(MAX_POINTERS_PER_REQUEST)
+    }
+  })
+
+  it('should request every pointer exactly once', () => {
+    expect(requestedBatches.flat().sort()).toEqual([...pointers].sort())
+  })
+
+  it('should resolve every pointer', () => {
+    expect(entities).toHaveLength(pointers.length)
+  })
+})
+
+describe('and the batch count is above the concurrency limit', () => {
+  let pointers: string[]
+  let maxInFlight: number
+
+  beforeEach(async () => {
+    pointers = generatePointers(MAX_POINTERS_PER_REQUEST * (MAX_CONCURRENT_POINTER_REQUESTS + 3))
+    let inFlight = 0
+    maxInFlight = 0
+    fetchBatch = jest.fn(async (batch: string[]) => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      await new Promise((resolve) => setImmediate(resolve))
+      inFlight--
+      return batch.map(generateEntity)
+    })
+    await fetchEntitiesInBatches(pointers, fetchBatch, logger)
+  })
+
+  it('should never hold more requests in flight than the concurrency limit', () => {
+    expect(maxInFlight).toBeLessThanOrEqual(MAX_CONCURRENT_POINTER_REQUESTS)
+  })
+
+  it('should still issue a request for every batch', () => {
+    expect(fetchBatch).toHaveBeenCalledTimes(MAX_CONCURRENT_POINTER_REQUESTS + 3)
+  })
+})
+
+describe('and one of the batches fails', () => {
+  let pointers: string[]
+  let entities: Entity[]
+
+  beforeEach(async () => {
+    pointers = generatePointers(MAX_POINTERS_PER_REQUEST * 2)
+    fetchBatch = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('content server unavailable'))
+      .mockImplementation(async (batch: string[]) => batch.map(generateEntity))
+    entities = await fetchEntitiesInBatches(pointers, fetchBatch, logger)
+  })
+
+  it('should return the entities resolved by the batches that succeeded', () => {
+    expect(entities).toHaveLength(MAX_POINTERS_PER_REQUEST)
+  })
+
+  it('should log a warning naming the failure', () => {
+    expect(logger.warn).toHaveBeenCalledWith('Failed to fetch a batch of entities', {
+      pointers: MAX_POINTERS_PER_REQUEST,
+      error: 'content server unavailable'
+    })
+  })
+})
+
+describe('when there are no pointers to resolve', () => {
+  let entities: Entity[]
+
+  beforeEach(async () => {
+    fetchBatch = jest.fn()
+    entities = await fetchEntitiesInBatches([], fetchBatch, logger)
+  })
+
+  it('should not issue any request', () => {
+    expect(fetchBatch).not.toHaveBeenCalled()
+  })
+
+  it('should return no entities', () => {
+    expect(entities).toEqual([])
+  })
+})

--- a/test/unit/logic/fetch-entities-in-batches.spec.ts
+++ b/test/unit/logic/fetch-entities-in-batches.spec.ts
@@ -1,6 +1,7 @@
 import { Entity, EntityType } from '@dcl/schemas'
 import { ILoggerComponent } from '@well-known-components/interfaces'
 import {
+  EntityBatchFailedError,
   MAX_CONCURRENT_POINTER_REQUESTS,
   MAX_POINTERS_PER_REQUEST,
   fetchEntitiesInBatches
@@ -45,7 +46,7 @@ describe('when the pointers fit in a single batch', () => {
 
   it('should issue a single request holding every pointer', () => {
     expect(fetchBatch).toHaveBeenCalledTimes(1)
-    expect(fetchBatch).toHaveBeenCalledWith(pointers)
+    expect(fetchBatch).toHaveBeenCalledWith(pointers, { abortController: expect.any(AbortController) })
   })
 
   it('should return one entity per pointer', () => {
@@ -91,7 +92,7 @@ describe('when the pointers exceed the maximum per request', () => {
   })
 })
 
-describe('and the batch count is above the concurrency limit', () => {
+describe('when the batch count is above the concurrency limit', () => {
   let pointers: string[]
   let maxInFlight: number
 
@@ -118,28 +119,75 @@ describe('and the batch count is above the concurrency limit', () => {
   })
 })
 
-describe('and one of the batches fails', () => {
+describe('when one of the batches fails', () => {
+  let pointers: string[]
+  let result: Promise<Entity[]>
+
+  beforeEach(() => {
+    // Three batches, all started at once under the concurrency limit: the first fails and
+    // the other two stay in flight until they are cancelled.
+    pointers = generatePointers(MAX_POINTERS_PER_REQUEST * 3)
+    let started = 0
+    fetchBatch = jest.fn(async (batch: string[], { abortController }: { abortController: AbortController }) => {
+      if (started++ === 0) {
+        throw new Error('content server unavailable')
+      }
+
+      await new Promise<void>((resolve) => {
+        if (abortController.signal.aborted) {
+          resolve()
+          return
+        }
+        abortController.signal.addEventListener('abort', () => resolve(), { once: true })
+      })
+
+      throw new Error('Request aborted (timed out)')
+    })
+    result = fetchEntitiesInBatches(pointers, fetchBatch, logger)
+  })
+
+  it('should reject instead of returning the entities the other batches resolved', async () => {
+    await expect(result).rejects.toThrow(EntityBatchFailedError)
+  })
+
+  it('should report the original failure rather than the cancellations it caused', async () => {
+    await expect(result).rejects.toThrow('content server unavailable')
+  })
+
+  it('should cancel the batches still in flight through a single shared controller', async () => {
+    await expect(result).rejects.toThrow()
+
+    const controllers = (fetchBatch.mock.calls as [string[], { abortController: AbortController }][]).map(
+      ([, options]) => options.abortController
+    )
+
+    expect(controllers).toHaveLength(3)
+    expect(new Set(controllers).size).toBe(1)
+    expect(controllers[0].signal.aborted).toBe(true)
+  })
+
+  it('should log a warning naming the failure', async () => {
+    await expect(result).rejects.toThrow()
+
+    expect(logger.warn).toHaveBeenCalledWith('Cancelled the remaining entity batches after one of them failed', {
+      batches: 3,
+      error: 'content server unavailable'
+    })
+  })
+})
+
+describe('when a batch resolves with no entities', () => {
   let pointers: string[]
   let entities: Entity[]
 
   beforeEach(async () => {
-    pointers = generatePointers(MAX_POINTERS_PER_REQUEST * 2)
-    fetchBatch = jest
-      .fn()
-      .mockRejectedValueOnce(new Error('content server unavailable'))
-      .mockImplementation(async (batch: string[]) => batch.map(generateEntity))
+    pointers = generatePointers(10)
+    fetchBatch = jest.fn().mockResolvedValue([])
     entities = await fetchEntitiesInBatches(pointers, fetchBatch, logger)
   })
 
-  it('should return the entities resolved by the batches that succeeded', () => {
-    expect(entities).toHaveLength(MAX_POINTERS_PER_REQUEST)
-  })
-
-  it('should log a warning naming the failure', () => {
-    expect(logger.warn).toHaveBeenCalledWith('Failed to fetch a batch of entities', {
-      pointers: MAX_POINTERS_PER_REQUEST,
-      error: 'content server unavailable'
-    })
+  it('should return no entities without treating the empty result as a failure', () => {
+    expect(entities).toEqual([])
   })
 })
 

--- a/test/unit/logic/fetch-entities-in-batches.spec.ts
+++ b/test/unit/logic/fetch-entities-in-batches.spec.ts
@@ -176,6 +176,66 @@ describe('when one of the batches fails', () => {
   })
 })
 
+describe('when cancelled sibling batches take time to settle', () => {
+  let releaseCancelledBatches: () => void
+  let resultSettled: boolean
+  let resultObservation: Promise<void>
+  let cancelledBatchesSettled: number
+
+  beforeEach(async () => {
+    const pointers = generatePointers(MAX_POINTERS_PER_REQUEST * 3)
+    let startedBatches = 0
+    let releaseCleanup: () => void = () => undefined
+    const cleanupGate = new Promise<void>((resolve) => {
+      releaseCleanup = resolve
+    })
+
+    releaseCancelledBatches = releaseCleanup
+    resultSettled = false
+    cancelledBatchesSettled = 0
+    fetchBatch = jest.fn(async (_batch, { abortController }) => {
+      if (startedBatches++ === 0) {
+        throw new Error('content server unavailable')
+      }
+
+      await new Promise<void>((resolve) => {
+        if (abortController.signal.aborted) {
+          resolve()
+        } else {
+          abortController.signal.addEventListener('abort', () => resolve(), { once: true })
+        }
+      })
+      await cleanupGate
+      cancelledBatchesSettled++
+      throw new Error('Request aborted (timed out)')
+    })
+
+    const result = fetchEntitiesInBatches(pointers, fetchBatch, logger)
+    resultObservation = result.then(
+      () => {
+        resultSettled = true
+      },
+      () => {
+        resultSettled = true
+      }
+    )
+
+    await new Promise<void>((resolve) => setImmediate(resolve))
+  })
+
+  it('should wait for cancelled sibling batches before rejecting', async () => {
+    const resultSettledBeforeCleanup = resultSettled
+
+    releaseCancelledBatches()
+    await resultObservation
+
+    expect({ cancelledBatchesSettled, resultSettledBeforeCleanup }).toEqual({
+      cancelledBatchesSettled: 2,
+      resultSettledBeforeCleanup: false
+    })
+  })
+})
+
 describe('when a batch resolves with no entities', () => {
   let pointers: string[]
   let entities: Entity[]


### PR DESCRIPTION
## Problem

`GET /explorer/:address/wearables` answers **500** for any wallet owning more than 1000 on-chain wearables, so the backpack never loads for them.

Reproducible in production today:

```
$ curl -s -o /dev/null -w '%{http_code}\n' \
    'https://peer.decentraland.org/explorer/<wallet>/wearables?collectionType=on-chain'
500
```

That wallet owns 1939 on-chain wearables. `collectionType=base-wearable` and `collectionType=third-party` both answer 200 for the same wallet, and a wallet with 79 on-chain wearables answers 200 for every collection type.

## Root cause

The content server validates `POST /entities/active` against a schema that caps `pointers` at 1000 items:

```json
{
  "instancePath": "/pointers",
  "schemaPath": "#/oneOf/1/properties/pointers/maxItems",
  "keyword": "maxItems",
  "params": { "limit": 1000 },
  "message": "must NOT have more than 1000 items"
}
```

Verified boundary against `peer.decentraland.org`: **1000 pointers → 200**, **1001 pointers → 400**.

`_fetchEntities` in `src/adapters/entities-fetcher.ts` sent every non-cached urn in one request:

```ts
const entities = await content.fetchEntitiesByPointers(nonCachedURNs)  // 1939 pointers
```

`fetchOnChainWearables` resolves *all* the wallet's items before paginating in memory, so the `pageSize` the client asks for does not bound this. Content answers 400, `fetchEntitiesByPointers` throws, and the handler turns it into a 500. It fails in ~85ms because the schema rejects the body before any lookup happens.

### Why this started failing recently

`_fetchEntities` has never batched — that code is unchanged since #165 (2023-05-12). What changed is the other side: catalyst [#1937](https://github.com/decentraland/catalyst/pull/1937) (merged 2026-06-12) replaced the Joi validation on `POST /entities/active` with a JSON Schema that added `maxItems: 1000`, closing catalyst#1935 (unauthenticated DoS via uncapped `ids`/`pointers`).

```diff
-    ids: Joi.array().items(Joi.string()).min(1).required()      // no upper bound
-    pointers: Joi.array().items(Joi.string()).min(1).required()
+    ids:      { type: 'array', items: {...}, minItems: 1, maxItems: 1000 }
+    pointers: { type: 'array', items: {...}, minItems: 1, maxItems: 1000 }
```

Before that there was no cap, so the unbatched request worked no matter how many items a wallet owned. The cap is the right call for that endpoint — this PR makes the caller respect it.

## Fix

Split the request into batches of 500. Because both public methods funnel through `_fetchEntities`, this also covers `fetchCollectionEntities`, which has the same problem for linked wearable collections over 1000 entities.

Also guards `entity.metadata?.id`: an entity without metadata used to throw a `TypeError` in the same loop, which was another path to a 500. Not the cause here (0 such entities among the 1939), but the same failure class.

Validated against production with the real 1939 urns: 4 batches of 500 → **1939/1939 entities resolved**, ~1.3s sequential.

## Tests

`test/unit/adapters/entities-fetcher.spec.ts` (new) — batching, cache reuse, and the missing-metadata guard.

`test/integration/explorer-handler.spec.ts` — a wallet with 1001 on-chain wearables against a content mock that rejects >1000 pointers, exactly as the real server does. It reproduces the production symptom: **500 before the fix, 200 after**, and asserts every request stays under the cap.

```
test/integration/explorer-handler.spec.ts   45 passed   (1 failed before the fix)
test/unit/adapters/entities-fetcher.spec.ts  4 passed   (2 failed before the fix)
yarn test                                  352 passed
yarn build / yarn lint:check               clean
```

The full integration run is flaky on `main` regardless of this branch (suites share a fixed `HTTP_SERVER_PORT` and hit `ECONNRESET`); both suites that differed between runs pass in isolation on `main` and on this branch.

## Impact

Any wallet with more than 1000 on-chain wearables not already cached, broken since 2026-06-12. Expect this to look intermittent near the boundary, since `nonCachedURNs` is what gets sent and `ITEMS_CACHE_MAX_SIZE` is per instance with a 10 minute TTL — which node you land on changes the count. Well past the limit, like the 1939 case, it fails every time.

`/explorer/:address/emotes` shares the code path and has the same ceiling.

Worth a sweep for other callers of `fetchEntitiesByPointers` with unbounded input — `src/adapters/profiles.ts` and `src/adapters/definitions-fetcher.ts` pass caller-supplied arrays straight through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
